### PR TITLE
커뮤니티 디테일 뷰(뷰 분리) & 댓글 입력창 추가 및 Delegate 패턴 작성, 적용 | 병합 요청

### DIFF
--- a/ReptileHub.xcodeproj/project.pbxproj
+++ b/ReptileHub.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		589CCFFD2C608FF100812D17 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CCFFC2C608FF100812D17 /* ProfileViewController.swift */; };
 		589CCFFF2C608FFF00812D17 /* CommunityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */; };
 		589CD0012C60901500812D17 /* GrowthDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */; };
+		58C61A042C7A530F00E1FD3A /* KeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C61A032C7A530F00E1FD3A /* KeyboardDelegate.swift */; };
 		58F3F6402C772E6B00FDABD1 /* CommunityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */; };
 		58F3F6422C781DF500FDABD1 /* AddPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6412C781DF500FDABD1 /* AddPostViewController.swift */; };
 		58F3F6442C781F1400FDABD1 /* AddPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6432C781F1400FDABD1 /* AddPostView.swift */; };
@@ -95,6 +96,7 @@
 		589CCFFC2C608FF100812D17 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityViewController.swift; sourceTree = "<group>"; };
 		589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthDiaryViewController.swift; sourceTree = "<group>"; };
+		58C61A032C7A530F00E1FD3A /* KeyboardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardDelegate.swift; sourceTree = "<group>"; };
 		58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityDetailView.swift; sourceTree = "<group>"; };
 		58F3F6412C781DF500FDABD1 /* AddPostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPostViewController.swift; sourceTree = "<group>"; };
 		58F3F6432C781F1400FDABD1 /* AddPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPostView.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 				58418D6E2C63FA3F004E738E /* CommunityTableViewCell.swift */,
 				5805AE182C7216CB00AB6ED9 /* CommentTableViewCell.swift */,
 				58F3F6432C781F1400FDABD1 /* AddPostView.swift */,
+				58C61A032C7A530F00E1FD3A /* KeyboardDelegate.swift */,
 			);
 			path = Community;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				4674B2E02C6464D700BCD451 /* TermsAgreementViewController.swift in Sources */,
 				588CE3DA2C524EA900338878 /* ViewController.swift in Sources */,
 				588CE3D62C524EA900338878 /* AppDelegate.swift in Sources */,
+				58C61A042C7A530F00E1FD3A /* KeyboardDelegate.swift in Sources */,
 				7968449C2C6AEC7100765A80 /* Spacing.swift in Sources */,
 				469B44382C62F3BC00B1C49B /* SocialLoginButton.swift in Sources */,
 				469B443C2C6305E300B1C49B /* AuthService.swift in Sources */,

--- a/ReptileHub.xcodeproj/project.pbxproj
+++ b/ReptileHub.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		589CCFFF2C608FFF00812D17 /* CommunityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */; };
 		589CD0012C60901500812D17 /* GrowthDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */; };
 		58F3F6402C772E6B00FDABD1 /* CommunityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */; };
+		58F3F6422C781DF500FDABD1 /* AddPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6412C781DF500FDABD1 /* AddPostViewController.swift */; };
+		58F3F6442C781F1400FDABD1 /* AddPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6432C781F1400FDABD1 /* AddPostView.swift */; };
 		7968449C2C6AEC7100765A80 /* Spacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7968449B2C6AEC7100765A80 /* Spacing.swift */; };
 		7968449E2C6B3DE600765A80 /* GrowthDiaryListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7968449D2C6B3DE600765A80 /* GrowthDiaryListCollectionViewCell.swift */; };
 		798476412C70E05200895D2D /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798476402C70E05200895D2D /* EmptyView.swift */; };
@@ -94,6 +96,8 @@
 		589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityViewController.swift; sourceTree = "<group>"; };
 		589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthDiaryViewController.swift; sourceTree = "<group>"; };
 		58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityDetailView.swift; sourceTree = "<group>"; };
+		58F3F6412C781DF500FDABD1 /* AddPostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPostViewController.swift; sourceTree = "<group>"; };
+		58F3F6432C781F1400FDABD1 /* AddPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPostView.swift; sourceTree = "<group>"; };
 		7968449B2C6AEC7100765A80 /* Spacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spacing.swift; sourceTree = "<group>"; };
 		7968449D2C6B3DE600765A80 /* GrowthDiaryListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthDiaryListCollectionViewCell.swift; sourceTree = "<group>"; };
 		798476402C70E05200895D2D /* EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
@@ -166,6 +170,7 @@
 				58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */,
 				58418D6E2C63FA3F004E738E /* CommunityTableViewCell.swift */,
 				5805AE182C7216CB00AB6ED9 /* CommentTableViewCell.swift */,
+				58F3F6432C781F1400FDABD1 /* AddPostView.swift */,
 			);
 			path = Community;
 			sourceTree = "<group>";
@@ -183,6 +188,7 @@
 			children = (
 				589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */,
 				583511FE2C692FBA00E7D63F /* CommunityDetailViewController.swift */,
+				58F3F6412C781DF500FDABD1 /* AddPostViewController.swift */,
 			);
 			path = Community;
 			sourceTree = "<group>";
@@ -374,6 +380,7 @@
 				589CCFFF2C608FFF00812D17 /* CommunityViewController.swift in Sources */,
 				589CCFFD2C608FF100812D17 /* ProfileViewController.swift in Sources */,
 				5805AE192C7216CB00AB6ED9 /* CommentTableViewCell.swift in Sources */,
+				58F3F6442C781F1400FDABD1 /* AddPostView.swift in Sources */,
 				588CE3D82C524EA900338878 /* SceneDelegate.swift in Sources */,
 				798476412C70E05200895D2D /* EmptyView.swift in Sources */,
 				79A1AE4A2C6A088D00D5711B /* TabbarViewController.swift in Sources */,
@@ -383,6 +390,7 @@
 				79AA14992C69C2F1009F8209 /* GrowthDiaryListView.swift in Sources */,
 				46F0F7EE2C6AE46400444C98 /* LoginView.swift in Sources */,
 				589CCFFB2C608FDE00812D17 /* TestModel.swift in Sources */,
+				58F3F6422C781DF500FDABD1 /* AddPostViewController.swift in Sources */,
 				4674B2E32C64D71700BCD451 /* AuthUser.swift in Sources */,
 				4693FAD02C60EB5200BB70D6 /* DiaryPostService.swift in Sources */,
 				58F3F6402C772E6B00FDABD1 /* CommunityDetailView.swift in Sources */,

--- a/ReptileHub.xcodeproj/project.pbxproj
+++ b/ReptileHub.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		589CCFFD2C608FF100812D17 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CCFFC2C608FF100812D17 /* ProfileViewController.swift */; };
 		589CCFFF2C608FFF00812D17 /* CommunityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */; };
 		589CD0012C60901500812D17 /* GrowthDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */; };
+		58F3F6402C772E6B00FDABD1 /* CommunityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */; };
 		7968449C2C6AEC7100765A80 /* Spacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7968449B2C6AEC7100765A80 /* Spacing.swift */; };
 		7968449E2C6B3DE600765A80 /* GrowthDiaryListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7968449D2C6B3DE600765A80 /* GrowthDiaryListCollectionViewCell.swift */; };
 		798476412C70E05200895D2D /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798476402C70E05200895D2D /* EmptyView.swift */; };
@@ -92,6 +93,7 @@
 		589CCFFC2C608FF100812D17 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityViewController.swift; sourceTree = "<group>"; };
 		589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthDiaryViewController.swift; sourceTree = "<group>"; };
+		58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityDetailView.swift; sourceTree = "<group>"; };
 		7968449B2C6AEC7100765A80 /* Spacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spacing.swift; sourceTree = "<group>"; };
 		7968449D2C6B3DE600765A80 /* GrowthDiaryListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowthDiaryListCollectionViewCell.swift; sourceTree = "<group>"; };
 		798476402C70E05200895D2D /* EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				5881F01F2C73122500FBB13E /* CommunityListView.swift */,
+				58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */,
 				58418D6E2C63FA3F004E738E /* CommunityTableViewCell.swift */,
 				5805AE182C7216CB00AB6ED9 /* CommentTableViewCell.swift */,
 			);
@@ -382,6 +385,7 @@
 				589CCFFB2C608FDE00812D17 /* TestModel.swift in Sources */,
 				4674B2E32C64D71700BCD451 /* AuthUser.swift in Sources */,
 				4693FAD02C60EB5200BB70D6 /* DiaryPostService.swift in Sources */,
+				58F3F6402C772E6B00FDABD1 /* CommunityDetailView.swift in Sources */,
 				589CD0012C60901500812D17 /* GrowthDiaryViewController.swift in Sources */,
 				469B443A2C62FDCA00B1C49B /* LoginViewController.swift in Sources */,
 				5881F0202C73122500FBB13E /* CommunityListView.swift in Sources */,

--- a/ReptileHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ReptileHub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,177 @@
+{
+  "originHash" : "730f223da394f1f4f387f30334c9415259b02991e9353a492cc6cccdc5f28544",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "21fe1af9be463a359aaf8d96789ef73fc3760d09",
+        "version" : "11.0.1"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "c89ed571ae140f8eb1142735e6e23d7bb8c34cb2",
+        "version" : "1.7.5"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "a5c253d1b4409eb8aef4346015ba000f9935cb2d",
+        "version" : "11.0.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "ca30c987b732d130732fb60b071e0b655a85ada7",
+        "version" : "11.0.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS",
+      "state" : {
+        "revision" : "a7965d134c5d3567026c523e0a8a583f73b62b0d",
+        "version" : "7.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "66dd81c729364b0425d0c2b73e38a489f32b1717",
+        "version" : "8.0.1"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version" : "1.65.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "66b3bddc2657e8ccb7a16fa0264aac99c57be09b",
+        "version" : "2.22.5"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
+      "state" : {
+        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
+        "version" : "5.7.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "e17d61f26df0f0e06f58f6977ba05a097a720106",
+        "version" : "1.27.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ReptileHub/Controller/Community/AddPostViewController.swift
+++ b/ReptileHub/Controller/Community/AddPostViewController.swift
@@ -1,0 +1,20 @@
+//
+//  AddPostViewController.swift
+//  ReptileHub
+//
+//  Created by 조성빈 on 8/23/24.
+//
+
+import UIKit
+
+class AddPostViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+ 
+}

--- a/ReptileHub/Controller/Community/CommunityDetailViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityDetailViewController.swift
@@ -34,19 +34,7 @@ class CommunityDetailViewController: UIViewController {
         detailView.remakeTableView()
     }
     
-//    override func viewIsAppearing(_ animated: Bool) {
-//        super.viewIsAppearing(animated)
-//        detailView.addGestureRecognizer(detailView.tapGesture)
-//        NotificationCenter.default.addObserver(detailView, selector: #selector(detailView.keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-////        NotificationCenter.default.addObserver(self, selector: #selector(detailView.keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-//    }
-//    
-//    override func viewWillDisappear(_ animated: Bool) {
-//        super.viewWillDisappear(animated)
-//        view.removeGestureRecognizer(detailView.tapGesture)
-//        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-//        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-//    }
+
 
     
     //MARK: - menu 버튼
@@ -105,6 +93,12 @@ extension CommunityDetailViewController: UITableViewDelegate, UITableViewDataSou
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         detailView.tableViewCellHeight(indexPath: indexPath, tableView: tableView)
     }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        print("댓글 셀 클릭")
+    }
+    
+    
 }
 
 extension CommunityDetailViewController: UITextViewDelegate {

--- a/ReptileHub/Controller/Community/CommunityDetailViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityDetailViewController.swift
@@ -9,67 +9,11 @@ import UIKit
 import SnapKit
 
 class CommunityDetailViewController: UIViewController {
-    
-    var dummyData = ["동해물과 백두산이 마르도 닳도록 하느님이 보우하사 우리나라 만세. 무궁화 삼천리 화려강산 대한사람 대한으로 부디 보전하세.", "커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~", "링딩동", "다크초코 6.7만 달성~", "커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~",]
-    
-    // 스크롤 뷰
-    private let scrollView: UIScrollView = UIScrollView()
-    private let stackView: UIStackView = UIStackView()
-    
-    // 상단 게시글 정보
-    private let profileImage: UIImageView = UIImageView()
-    
-    private let titleLabel: UILabel = UILabel()
-    private let nicknameLabel: UILabel = UILabel()
-    private let timestampLabel: UILabel = UILabel()
-    private let elementStackView: UIStackView = UIStackView()
-    
-    private let likeButton: UIButton = UIButton()
+
+    let detailView = CommunityDetailView()
     
     private var menuButton: UIBarButtonItem = UIBarButtonItem()
-    
-    private let titleStackView: UIStackView = UIStackView()
-    
-    // 상단 게시글 정보와 게시글 본문 사이의 구분선
-    private let divisionLine: UIView = UIView()
-    
-    // 본문 이미지
-    private let contentImages: [UIImageView] = [
-        UIImageView(image: UIImage(named: "choba")),
-        UIImageView(image: UIImage(named: "cookie")),
-        UIImageView(image: UIImage(named: "cookie")),
-    ]
-    private var imageViews: [UIView] = []
-    private let imageStackView: UIStackView = UIStackView()
-    private let imageScrollView: UIScrollView = UIScrollView()
-    // 이미지 개수 나타내는 UI
-    private let imagePageCount: UILabel = UILabel()
-    private let pageCountView: UIView = UIView()
-    
-    // 본문 텍스트
-    private let contentText: UILabel = UILabel()
-    
-    // 좋아요, 댓글 개수
-    private let likeCount: UILabel = UILabel()
-    private let commentCount: UILabel = UILabel()
-    private let countInfoStackView: UIStackView = UIStackView()
-    
-    // 본문과 댓글 구분선
-    private let divisionThickLine: UIView = UIView()
-    
-    // 댓글 부분
-    private let commentTableView: UITableView = UITableView(frame: .zero)
-    
-    // 댓글의 높이를 계산하기위한 변수
-    private var tableViewHeight: CGFloat = 0.0
-    private var rowHeights: [IndexPath: CGFloat] = [:]
-    
-    // 댓글 작성란
-    private let commentBackgroundView: UIView = UIView()
-    private let commentTextView: UITextView = UITextView()
-    private let sendButton: UIButton = UIButton()
-    private let placeHolder: UILabel = UILabel()
-    
+  
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -78,83 +22,18 @@ class CommunityDetailViewController: UIViewController {
         
         self.title = "커뮤니티"
         
-        setupCommentStackView()
-        setupMainScrollView()
-        setupProfileImage()
-        setupElementStackView()
         setupMenuButton()
-        setupTitleStackView()
-        setupDivisionLine()
-        setupImageScrollView()
-        setupImagePageCountLabel()
-        setupTextView()
-        setupCountInfoStackView()
-        setupDivisionThickLine()
-        setupCommentTableView()
-        
+        setupDetailView()
     }
     
-    
-    //MARK: - 스크롤뷰 세팅
-    private func setupMainScrollView() {
-        scrollView.alwaysBounceVertical = true
-        scrollView.backgroundColor = .green
-        
-        stackView.axis = .vertical
-        stackView.distribution = .equalCentering
-        stackView.alignment = .firstBaseline
-        stackView.backgroundColor = .red
-        
-        self.view.addSubview(scrollView)
-        
-        scrollView.addSubview(stackView)
-        
-        scrollView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
-            make.bottom.equalTo(commentBackgroundView.snp.top)
-            make.width.equalTo(self.view.frame.width)
-            make.height.lessThanOrEqualTo(self.view.frame.height - commentBackgroundView.frame.height)
-        }
-        
-        stackView.snp.makeConstraints { make in
-            //            make.top.leading.trailing.equalTo(scrollView)
-            //            make.height.equalTo(self.view.frame.height)
-            make.top.leading.trailing.bottom.equalTo(scrollView.contentLayoutGuide)
-            make.width.equalTo(scrollView.snp.width)
-        }
-        
-        let stackViewHeight = stackView.heightAnchor.constraint(greaterThanOrEqualTo: self.view.heightAnchor)
-        stackViewHeight.priority = .defaultLow
-        stackViewHeight.isActive = true
+    override func viewWillAppear(_ animated: Bool) {
+        detailView.initHeightValue()
     }
     
-    //MARK: - 프로필 이미지
-    private func setupProfileImage() {
-        profileImage.image = UIImage(systemName: "person")
-        profileImage.backgroundColor = .green
-        profileImage.layer.cornerRadius = 30
-        profileImage.clipsToBounds = true
+    override func viewDidAppear(_ animated: Bool) {
+        detailView.remakeTableView()
     }
-    
-    //MARK: - 제목, 닉네임, 시간 StackView(elementStackView)
-    private func setupElementStackView() {
-        titleLabel.text = "공부는 최대한 미뤄라."
-        titleLabel.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
-        nicknameLabel.text = "공부싫어"
-        nicknameLabel.font = UIFont.systemFont(ofSize: 12, weight: .regular)
-        timestampLabel.text = "24.08.09 17:31"
-        timestampLabel.font = UIFont.systemFont(ofSize: 10, weight: .light)
-        timestampLabel.textColor = UIColor.lightGray
-        
-        elementStackView.axis = .vertical
-        elementStackView.distribution = .fillEqually
-        elementStackView.alignment = .leading
-        elementStackView.backgroundColor = .systemPink
-        
-        elementStackView.addArrangedSubview(titleLabel)
-        elementStackView.addArrangedSubview(nicknameLabel)
-        elementStackView.addArrangedSubview(timestampLabel)
-    }
+
     
     //MARK: - menu 버튼
     private func setupMenuButton() {
@@ -173,396 +52,49 @@ class CommunityDetailViewController: UIViewController {
         self.navigationItem.rightBarButtonItem = menuButton
     }
     
+    //MARK: - 커뮤니티 디테일 뷰 setup
+    private func setupDetailView() {
+        self.view = detailView
+        detailView.backgroundColor = .white
+        detailView.configureTableView(scrollViewDelegate: self, tableViewDelegate: self, tableViewDatasource: self, textViewDelegate: self)
+    }
+    
     @objc
     private func actionMenuButton() {
         print("메뉴 버튼 클릭.")
     }
     
-    //MARK: - title StackView + 좋아요 버튼
-    private func setupTitleStackView() {
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
-        let heartImage = UIImage(systemName: "heart", withConfiguration: imageConfig)
-        
-        likeButton.setImage(heartImage, for: .normal)
-        
-        likeButton.snp.makeConstraints { make in
-            make.width.equalTo(40)
-        }
-        
-        titleStackView.axis = .horizontal
-        titleStackView.distribution = .fill
-        titleStackView.alignment = .center
-        titleStackView.spacing = 10
-        titleStackView.backgroundColor = .yellow
-        
-        titleStackView.addArrangedSubview(profileImage)
-        titleStackView.addArrangedSubview(elementStackView)
-        titleStackView.addArrangedSubview(likeButton)
-        
-        self.stackView.addArrangedSubview(titleStackView)
-        
-        titleStackView.snp.makeConstraints { make in
-            make.top.equalTo(self.stackView.snp.top)
-            make.leading.equalTo(self.stackView.snp.leading).offset(24)
-            make.trailing.equalTo(self.stackView.snp.trailing).offset(-24)
-            make.height.equalTo(60)
-        }
-        
-        profileImage.snp.makeConstraints { make in
-            make.height.width.equalTo(60)
-            make.leading.equalTo(titleStackView.snp.leading)
-        }
-        
-        elementStackView.snp.makeConstraints { make in
-            make.leading.equalTo(profileImage.snp.trailing).offset(10)
-            make.trailing.equalTo(titleStackView.snp.trailing)
-            make.height.equalTo(50)
-        }
-    }
-    
-    //MARK: - 제목, 본문과의 구분선
-    private func setupDivisionLine() {
-        divisionLine.backgroundColor = .lightGray
-        
-        self.stackView.addArrangedSubview(divisionLine)
-        
-        divisionLine.snp.makeConstraints { make in
-            make.height.equalTo(0.5)
-            make.top.equalTo(titleStackView.snp.bottom).offset(12)
-            make.leading.equalTo(self.stackView.snp.leading)
-            make.trailing.equalTo(self.stackView.snp.trailing)
-        }
-    }
-    
-    //MARK: - 본문 이미지, 스크롤뷰
-    private func setupImageScrollView() {
-        imageStackView.axis = .horizontal
-        imageStackView.distribution = .fill
-        imageStackView.alignment = .center
-        imageStackView.backgroundColor = .green
-        
-        for i in 0..<contentImages.count {
-            let imageView: UIView = UIView(frame: CGRect(x: 0, y: 0, width: imageScrollView.frame.width, height: imageScrollView.frame.height))
-            
-            contentImages[i].contentMode = .scaleAspectFit
-            
-            imageView.addSubview(contentImages[i])
-            
-            contentImages[i].snp.makeConstraints { make in
-                make.centerX.equalTo(imageView)
-                make.height.equalTo(230)
-            }
-            
-            imageViews.append(imageView)
-        }
-        
-        for imageView in imageViews {
-            imageView.backgroundColor = .gray
-            imageView.snp.makeConstraints { make in
-                make.height.equalTo(230)
-                make.width.equalTo(self.view.frame.width)
-            }
-            imageStackView.addArrangedSubview(imageView)
-        }
-        
-        imageScrollView.alwaysBounceHorizontal = true
-        imageScrollView.addSubview(imageStackView)
-        imageScrollView.isPagingEnabled = true
-        imageScrollView.delegate = self
-        
-        self.stackView.addArrangedSubview(imageScrollView)
-        
-        imageScrollView.snp.makeConstraints { make in
-            make.height.equalTo(230)
-            make.top.equalTo(divisionLine.snp.bottom).offset(12)
-            make.leading.equalTo(self.stackView.snp.leading)
-            make.trailing.equalTo(self.stackView.snp.trailing)
-        }
-        
-        imageStackView.snp.makeConstraints { make in
-            make.top.leading.trailing.bottom.equalTo(imageScrollView)
-        }
-    }
-    
-    //MARK: - 본문 이미지의 페이지 현황
-    private func setupImagePageCountLabel() {
-        pageCountView.backgroundColor = .lightGray
-        pageCountView.layer.cornerRadius = 12
-        
-        pageCountView.addSubview(imagePageCount)
-        
-        self.stackView.addArrangedSubview(pageCountView)
-        
-        pageCountView.snp.makeConstraints { make in
-            make.height.equalTo(27)
-            make.width.equalTo(40)
-            make.trailing.equalTo(imageScrollView.snp.trailing).offset(-10)
-            make.bottom.equalTo(imageScrollView.snp.bottom).offset(-10)
-        }
-        
-        imagePageCount.text = "1/\(contentImages.count)"
-        imagePageCount.backgroundColor = .lightGray
-        
-        imagePageCount.snp.makeConstraints { make in
-            make.centerX.equalTo(pageCountView)
-            make.centerY.equalTo(pageCountView)
-        }
-    }
-    
-    //MARK: - 본문 내용
-    private func setupTextView() {
-        contentText.text = "게시글 본문 예시 내용입니다."
-        contentText.font = UIFont.systemFont(ofSize: 14, weight: .medium)
-        contentText.backgroundColor = .lightGray
-        
-        self.stackView.addArrangedSubview(contentText)
-        
-        contentText.snp.makeConstraints { make in
-            make.top.equalTo(imageScrollView.snp.bottom).offset(10)
-            make.leading.trailing.equalTo(titleStackView)
-            make.height.greaterThanOrEqualTo(80)
-        }
-    }
-    
-    //MARK: - count info stackview - 좋아요, 댓글 수 스택뷰
-    private func setupCountInfoStackView() {
-        let likeImage = UIImageView(image: UIImage(systemName: "heart"))
-        let commentImage = UIImageView(image: UIImage(systemName: "message"))
-        
-        countInfoStackView.axis = .horizontal
-        countInfoStackView.distribution = .fill
-        countInfoStackView.spacing = 5
-        countInfoStackView.alignment = .center
-        
-        likeCount.text = "123"
-        commentCount.text = "123"
-        
-        countInfoStackView.addArrangedSubview(likeImage)
-        countInfoStackView.addArrangedSubview(likeCount)
-        countInfoStackView.addArrangedSubview(commentImage)
-        countInfoStackView.addArrangedSubview(commentCount)
-        
-        self.stackView.addArrangedSubview(countInfoStackView)
-        
-        countInfoStackView.snp.makeConstraints { make in
-            make.top.equalTo(contentText.snp.bottom).offset(10)
-            make.leading.equalTo(contentText.snp.leading)
-            make.height.equalTo(20)
-        }
-    }
-    
-    //MARK: - 본문과 댓글 사이의 구분선(두꺼움)
-    private func setupDivisionThickLine() {
-        divisionThickLine.backgroundColor = .lightGray
-        
-        self.stackView.addArrangedSubview(divisionThickLine)
-        
-        divisionThickLine.snp.makeConstraints { make in
-            make.height.equalTo(10)
-            make.top.equalTo(countInfoStackView.snp.bottom).offset(10)
-            make.leading.trailing.equalTo(self.view)
-            
-        }
-    }
-    
-    //MARK: - 댓글 테이블 뷰
-    private func setupCommentTableView() {
-        let headerView: UILabel = UILabel()
-        headerView.text = "댓글"
-        headerView.backgroundColor = .yellow
-        headerView.frame = CGRect(x: 0, y: 0, width: 0, height: 40)
-        
-        commentTableView.delegate = self
-        commentTableView.dataSource = self
-        commentTableView.register(CommentTableViewCell.self, forCellReuseIdentifier: "commentCell")
-        commentTableView.isScrollEnabled = false
-        commentTableView.backgroundColor = .lightGray
-        commentTableView.estimatedRowHeight = 60
-        commentTableView.rowHeight = UITableView.automaticDimension
-        commentTableView.tableHeaderView = headerView
-        
-        self.stackView.addArrangedSubview(commentTableView)
-        
-        commentTableView.translatesAutoresizingMaskIntoConstraints = false
-        
-        var resultHeight: CGFloat = 0.0
-        for comment in dummyData {
-            let height = getLabelHeight(text: comment)
-            resultHeight += height
-        }
-        
-        commentTableView.snp.makeConstraints { make in
-            make.top.equalTo(divisionThickLine.snp.bottom)
-            make.leading.equalTo(self.stackView.snp.leading).offset(24)
-            make.trailing.equalTo(self.stackView.snp.trailing).offset(-24)
-            make.bottom.equalTo(self.stackView.snp.bottom)
-            make.height.equalTo(resultHeight)
-        }
-    }
-    
-    //MARK: - UILabel의 높이를 측정하는 메서드
-    func getLabelHeight(text: String) -> CGFloat {
-        let label = UILabel(
-            frame: .init(
-                x: .zero,
-                y: .zero,
-                width: commentTableView.frame.width - 75,
-                height: .greatestFiniteMagnitude
-            )
-        )
-        label.text = text
-        label.numberOfLines = 0
-        label.font = .systemFont(ofSize: 13)
-        label.sizeToFit()
-        let labelHeight = label.frame.height
-        return labelHeight
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        // 뷰가 나타날 때 해당 값들을 초기화함.
-        tableViewHeight = 0.0
-        rowHeights = [:]
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        // 뷰가 나타나고 셀의 크기를 취합하여 테이블 뷰의 레이아웃(높이)를 다시 잡음.
-        commentTableView.snp.remakeConstraints { make in
-            make.top.equalTo(divisionThickLine.snp.bottom)
-            make.leading.equalTo(self.stackView.snp.leading).offset(24)
-            make.trailing.equalTo(self.stackView.snp.trailing).offset(-24)
-            make.bottom.equalTo(self.stackView.snp.bottom)
-            make.height.equalTo(tableViewHeight + 40) // 40은 위ㅔㅇ서 지정한 테이블뷰-헤더뷰 크기임.
-        }
-    }
-    
-    
-    //MARK: - 댓글 작성란 setup
-    private func setupCommentStackView() {
-        commentTextView.layer.cornerRadius = 10
-        commentTextView.font = UIFont.systemFont(ofSize: 18)
-        commentTextView.isScrollEnabled = false
-        commentTextView.delegate = self
-        commentTextView.textContainer.lineFragmentPadding = 15
-        commentTextView.backgroundColor = .lightGray
-        
-        placeHolder.text = "댓글을 남겨보세요"
-        placeHolder.font = UIFont.systemFont(ofSize: 18, weight: .light)
-        placeHolder.textColor = .white
-        
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 25)
-        let planeImage = UIImage(systemName: "paperplane.fill", withConfiguration: imageConfig)
-        sendButton.setImage(planeImage, for: .normal)
-        
-        commentBackgroundView.backgroundColor = .gray
-        
-        self.view.addSubview(commentBackgroundView)
-        
-        commentBackgroundView.snp.makeConstraints { make in
-            make.width.equalTo(self.view.frame.width)
-            make.height.greaterThanOrEqualTo(40)
-            make.leading.trailing.equalTo(self.view)
-            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
-        }
-        
-        commentBackgroundView.addSubview(commentTextView)
-        commentBackgroundView.addSubview(sendButton)
-        commentTextView.addSubview(placeHolder)
-        
-        sendButton.snp.makeConstraints { make in
-            make.trailing.equalTo(commentBackgroundView.snp.trailing)
-            make.bottom.equalTo(commentBackgroundView.snp.bottom).offset(-3)
-            make.height.width.equalTo(40)
-        }
-        
-        commentTextView.snp.makeConstraints { make in
-            make.top.equalTo(commentBackgroundView.snp.top).offset(5)
-            make.leading.equalTo(commentBackgroundView.snp.leading).offset(10)
-            make.trailing.equalTo(sendButton.snp.leading)
-            make.bottom.equalTo(commentBackgroundView.snp.bottom).offset(-5)
-            make.height.greaterThanOrEqualTo(30) // 최소 높이를 30으로 설정
-            make.width.equalTo(342)
-        }
-        
-        placeHolder.snp.makeConstraints { make in
-            make.centerY.equalTo(commentTextView)
-            make.leading.equalTo(commentTextView.snp.leading).offset(15)
-        }
-    }
+
+
     
 }
 
 
 extension CommunityDetailViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard scrollView.frame.width > 0 else {
-            return
-        }
-        let pageIndex = round(scrollView.contentOffset.x / scrollView.frame.width)
-        self.imagePageCount.text = "\(Int(pageIndex) + 1)/\(self.contentImages.count)"
+        detailView.imageScrollCount(scrollView: scrollView)
     }
 }
 
 extension CommunityDetailViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        dummyData.count
+        detailView.dummyData.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "commentCell", for: indexPath) as! CommentTableViewCell
-        cell.commentText = dummyData[indexPath.row]
+        cell.commentText = detailView.dummyData[indexPath.row]
         cell.configureCell()
         return cell
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if let cachedHeight = rowHeights[indexPath] {
-            return cachedHeight
-        }
-        
-        let labelHeight = getLabelHeight(text: dummyData[indexPath.row])
-        
-        // 50 = cell의 commentLabel의 버티컬 패딩 값 조절을 위한 값 / 증가(패딩 증가) / 감소(패딩 감소)
-        tableViewHeight += (labelHeight + 50)
-        rowHeights[indexPath] = labelHeight + 50
-        return labelHeight
+        detailView.tableViewCellHeight(indexPath: indexPath, tableView: tableView)
     }
 }
 
 extension CommunityDetailViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
-        let size = CGSize(width: commentTextView.frame.width, height: .greatestFiniteMagnitude)
-        let estimatedSize = textView.sizeThatFits(size)
-        
-        print("현재 텍스트뷰 높이 : \(estimatedSize.height), \(estimatedSize.width)")
-        
-        if textView.text == "" {
-            placeHolder.textColor = .white
-            textView.layoutIfNeeded()
-        } else {
-            placeHolder.textColor = .clear
-        }
-        
-        if estimatedSize.height > 102 {
-            textView.isScrollEnabled = true
-            
-            textView.constraints.forEach { constraint in
-                if constraint.firstAttribute == .height {
-                    constraint.constant = 102
-                }
-            }
-        } else {
-            textView.isScrollEnabled = false
-            textView.constraints.forEach { constraint in
-                if constraint.firstAttribute == .height {
-                    constraint.constant = estimatedSize.height
-                }
-            }
-        }
-        
-        // textView 18 Font 기준
-        // 1줄 - 37.6666
-        // 2줄 - 59.0
-        // 3줄 - 80.6666
-        // 4줄 - 102.0
+        detailView.textViewChange(textView: textView)
     }
 }

--- a/ReptileHub/Controller/Community/CommunityDetailViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityDetailViewController.swift
@@ -33,6 +33,20 @@ class CommunityDetailViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         detailView.remakeTableView()
     }
+    
+//    override func viewIsAppearing(_ animated: Bool) {
+//        super.viewIsAppearing(animated)
+//        detailView.addGestureRecognizer(detailView.tapGesture)
+//        NotificationCenter.default.addObserver(detailView, selector: #selector(detailView.keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+////        NotificationCenter.default.addObserver(self, selector: #selector(detailView.keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+//    }
+//    
+//    override func viewWillDisappear(_ animated: Bool) {
+//        super.viewWillDisappear(animated)
+//        view.removeGestureRecognizer(detailView.tapGesture)
+//        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+//        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
+//    }
 
     
     //MARK: - menu 버튼

--- a/ReptileHub/Controller/Community/CommunityDetailViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityDetailViewController.swift
@@ -60,16 +60,25 @@ class CommunityDetailViewController: UIViewController {
     // 댓글 부분
     private let commentTableView: UITableView = UITableView(frame: .zero)
     
+    // 댓글의 높이를 계산하기위한 변수
     private var tableViewHeight: CGFloat = 0.0
     private var rowHeights: [IndexPath: CGFloat] = [:]
-
+    
+    // 댓글 작성란
+    private let commentBackgroundView: UIView = UIView()
+    private let commentTextView: UITextView = UITextView()
+    private let sendButton: UIButton = UIButton()
+    private let placeHolder: UILabel = UILabel()
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.view.backgroundColor = .white
-
+        
         self.title = "커뮤니티"
         
+        setupCommentStackView()
         setupMainScrollView()
         setupProfileImage()
         setupElementStackView()
@@ -101,12 +110,15 @@ class CommunityDetailViewController: UIViewController {
         scrollView.addSubview(stackView)
         
         scrollView.snp.makeConstraints { make in
-            make.top.leading.trailing.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            make.top.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
+            make.bottom.equalTo(commentBackgroundView.snp.top)
+            make.width.equalTo(self.view.frame.width)
+            make.height.lessThanOrEqualTo(self.view.frame.height - commentBackgroundView.frame.height)
         }
         
         stackView.snp.makeConstraints { make in
-//            make.top.leading.trailing.equalTo(scrollView)
-//            make.height.equalTo(self.view.frame.height)
+            //            make.top.leading.trailing.equalTo(scrollView)
+            //            make.height.equalTo(self.view.frame.height)
             make.top.leading.trailing.bottom.equalTo(scrollView.contentLayoutGuide)
             make.width.equalTo(scrollView.snp.width)
         }
@@ -147,18 +159,18 @@ class CommunityDetailViewController: UIViewController {
     //MARK: - menu 버튼
     private func setupMenuButton() {
         let ellipsisImage = UIImage(systemName: "ellipsis")
-            
-            // UIButton을 생성하여 회전
-            let button = UIButton(type: .system)
-            button.setImage(ellipsisImage, for: .normal)
-            button.tintColor = .black
-            button.transform = CGAffineTransform(rotationAngle: .pi / 2) // 90도 회전
-            
-            button.addTarget(self, action: #selector(actionMenuButton), for: .touchUpInside)
-            
-            menuButton = UIBarButtonItem(customView: button)
         
-            self.navigationItem.rightBarButtonItem = menuButton
+        // UIButton을 생성하여 회전
+        let button = UIButton(type: .system)
+        button.setImage(ellipsisImage, for: .normal)
+        button.tintColor = .black
+        button.transform = CGAffineTransform(rotationAngle: .pi / 2) // 90도 회전
+        
+        button.addTarget(self, action: #selector(actionMenuButton), for: .touchUpInside)
+        
+        menuButton = UIBarButtonItem(customView: button)
+        
+        self.navigationItem.rightBarButtonItem = menuButton
     }
     
     @objc
@@ -170,7 +182,7 @@ class CommunityDetailViewController: UIViewController {
     private func setupTitleStackView() {
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
         let heartImage = UIImage(systemName: "heart", withConfiguration: imageConfig)
-    
+        
         likeButton.setImage(heartImage, for: .normal)
         
         likeButton.snp.makeConstraints { make in
@@ -214,7 +226,7 @@ class CommunityDetailViewController: UIViewController {
         
         self.stackView.addArrangedSubview(divisionLine)
         
-        divisionLine.snp.makeConstraints { (make) -> Void in
+        divisionLine.snp.makeConstraints { make in
             make.height.equalTo(0.5)
             make.top.equalTo(titleStackView.snp.bottom).offset(12)
             make.leading.equalTo(self.stackView.snp.leading)
@@ -236,7 +248,7 @@ class CommunityDetailViewController: UIViewController {
             
             imageView.addSubview(contentImages[i])
             
-            contentImages[i].snp.makeConstraints { (make) -> Void in
+            contentImages[i].snp.makeConstraints { make in
                 make.centerX.equalTo(imageView)
                 make.height.equalTo(230)
             }
@@ -246,7 +258,7 @@ class CommunityDetailViewController: UIViewController {
         
         for imageView in imageViews {
             imageView.backgroundColor = .gray
-            imageView.snp.makeConstraints { (make) -> Void in
+            imageView.snp.makeConstraints { make in
                 make.height.equalTo(230)
                 make.width.equalTo(self.view.frame.width)
             }
@@ -260,25 +272,25 @@ class CommunityDetailViewController: UIViewController {
         
         self.stackView.addArrangedSubview(imageScrollView)
         
-        imageScrollView.snp.makeConstraints { (make) -> Void in
+        imageScrollView.snp.makeConstraints { make in
             make.height.equalTo(230)
             make.top.equalTo(divisionLine.snp.bottom).offset(12)
             make.leading.equalTo(self.stackView.snp.leading)
             make.trailing.equalTo(self.stackView.snp.trailing)
         }
         
-        imageStackView.snp.makeConstraints { (make) -> Void in
+        imageStackView.snp.makeConstraints { make in
             make.top.leading.trailing.bottom.equalTo(imageScrollView)
         }
     }
-
+    
     //MARK: - 본문 이미지의 페이지 현황
     private func setupImagePageCountLabel() {
         pageCountView.backgroundColor = .lightGray
         pageCountView.layer.cornerRadius = 12
         
         pageCountView.addSubview(imagePageCount)
-
+        
         self.stackView.addArrangedSubview(pageCountView)
         
         pageCountView.snp.makeConstraints { make in
@@ -388,6 +400,7 @@ class CommunityDetailViewController: UIViewController {
         }
     }
     
+    //MARK: - UILabel의 높이를 측정하는 메서드
     func getLabelHeight(text: String) -> CGFloat {
         let label = UILabel(
             frame: .init(
@@ -406,11 +419,13 @@ class CommunityDetailViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        // 뷰가 나타날 때 해당 값들을 초기화함.
         tableViewHeight = 0.0
         rowHeights = [:]
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        // 뷰가 나타나고 셀의 크기를 취합하여 테이블 뷰의 레이아웃(높이)를 다시 잡음.
         commentTableView.snp.remakeConstraints { make in
             make.top.equalTo(divisionThickLine.snp.bottom)
             make.leading.equalTo(self.stackView.snp.leading).offset(24)
@@ -419,12 +434,69 @@ class CommunityDetailViewController: UIViewController {
             make.height.equalTo(tableViewHeight + 40) // 40은 위ㅔㅇ서 지정한 테이블뷰-헤더뷰 크기임.
         }
     }
-
+    
+    
+    //MARK: - 댓글 작성란 setup
+    private func setupCommentStackView() {
+        commentTextView.layer.cornerRadius = 10
+        commentTextView.font = UIFont.systemFont(ofSize: 18)
+        commentTextView.isScrollEnabled = false
+        commentTextView.delegate = self
+        commentTextView.textContainer.lineFragmentPadding = 15
+        commentTextView.backgroundColor = .lightGray
+        
+        placeHolder.text = "댓글을 남겨보세요"
+        placeHolder.font = UIFont.systemFont(ofSize: 18, weight: .light)
+        placeHolder.textColor = .white
+        
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 25)
+        let planeImage = UIImage(systemName: "paperplane.fill", withConfiguration: imageConfig)
+        sendButton.setImage(planeImage, for: .normal)
+        
+        commentBackgroundView.backgroundColor = .gray
+        
+        self.view.addSubview(commentBackgroundView)
+        
+        commentBackgroundView.snp.makeConstraints { make in
+            make.width.equalTo(self.view.frame.width)
+            make.height.greaterThanOrEqualTo(40)
+            make.leading.trailing.equalTo(self.view)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+        }
+        
+        commentBackgroundView.addSubview(commentTextView)
+        commentBackgroundView.addSubview(sendButton)
+        commentTextView.addSubview(placeHolder)
+        
+        sendButton.snp.makeConstraints { make in
+            make.trailing.equalTo(commentBackgroundView.snp.trailing)
+            make.bottom.equalTo(commentBackgroundView.snp.bottom).offset(-3)
+            make.height.width.equalTo(40)
+        }
+        
+        commentTextView.snp.makeConstraints { make in
+            make.top.equalTo(commentBackgroundView.snp.top).offset(5)
+            make.leading.equalTo(commentBackgroundView.snp.leading).offset(10)
+            make.trailing.equalTo(sendButton.snp.leading)
+            make.bottom.equalTo(commentBackgroundView.snp.bottom).offset(-5)
+            make.height.greaterThanOrEqualTo(30) // 최소 높이를 30으로 설정
+            make.width.equalTo(342)
+        }
+        
+        placeHolder.snp.makeConstraints { make in
+            make.centerY.equalTo(commentTextView)
+            make.leading.equalTo(commentTextView.snp.leading).offset(15)
+        }
+    }
+    
 }
 
 
 extension CommunityDetailViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard scrollView.frame.width > 0 else {
+            return
+        }
         let pageIndex = round(scrollView.contentOffset.x / scrollView.frame.width)
         self.imagePageCount.text = "\(Int(pageIndex) + 1)/\(self.contentImages.count)"
     }
@@ -453,5 +525,44 @@ extension CommunityDetailViewController: UITableViewDelegate, UITableViewDataSou
         tableViewHeight += (labelHeight + 50)
         rowHeights[indexPath] = labelHeight + 50
         return labelHeight
+    }
+}
+
+extension CommunityDetailViewController: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        let size = CGSize(width: commentTextView.frame.width, height: .greatestFiniteMagnitude)
+        let estimatedSize = textView.sizeThatFits(size)
+        
+        print("현재 텍스트뷰 높이 : \(estimatedSize.height), \(estimatedSize.width)")
+        
+        if textView.text == "" {
+            placeHolder.textColor = .white
+            textView.layoutIfNeeded()
+        } else {
+            placeHolder.textColor = .clear
+        }
+        
+        if estimatedSize.height > 102 {
+            textView.isScrollEnabled = true
+            
+            textView.constraints.forEach { constraint in
+                if constraint.firstAttribute == .height {
+                    constraint.constant = 102
+                }
+            }
+        } else {
+            textView.isScrollEnabled = false
+            textView.constraints.forEach { constraint in
+                if constraint.firstAttribute == .height {
+                    constraint.constant = estimatedSize.height
+                }
+            }
+        }
+        
+        // textView 18 Font 기준
+        // 1줄 - 37.6666
+        // 2줄 - 59.0
+        // 3줄 - 80.6666
+        // 4줄 - 102.0
     }
 }

--- a/ReptileHub/Controller/Community/CommunityViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityViewController.swift
@@ -57,5 +57,9 @@ extension CommunityViewController: UITableViewDelegate, UITableViewDataSource {
         return cell
     }
     
-    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let detailViewController = CommunityDetailViewController()
+        detailViewController.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(detailViewController, animated: true)
+    }
 }

--- a/ReptileHub/Controller/Profile/ProfileViewController.swift
+++ b/ReptileHub/Controller/Profile/ProfileViewController.swift
@@ -6,14 +6,16 @@
 //
 
 import UIKit
+import SnapKit
 
 class ProfileViewController: UIViewController {
+    
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
     }
+    
     
 
     /*

--- a/ReptileHub/Controller/TabbarViewController.swift
+++ b/ReptileHub/Controller/TabbarViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class TabbarViewController: UITabBarController {
 
-    let communityVC = CommunityDetailViewController()
+    let communityVC = CommunityViewController()
     let diaryVC = GrowthDiaryViewController()
     let profileVC = ProfileViewController()
 

--- a/ReptileHub/Controller/TabbarViewController.swift
+++ b/ReptileHub/Controller/TabbarViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class TabbarViewController: UITabBarController {
 
-    let communityVC = CommunityViewController()
+    let communityVC = CommunityDetailViewController()
     let diaryVC = GrowthDiaryViewController()
     let profileVC = ProfileViewController()
 
@@ -26,8 +26,6 @@ class TabbarViewController: UITabBarController {
         
         self.viewControllers = [firstNavigationController, secondNavigationController, thirdNavigationController]
     }
-    
-
     
     
 

--- a/ReptileHub/SceneDelegate.swift
+++ b/ReptileHub/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         
-        self.window?.rootViewController = TabbarViewController()
+        self.window?.rootViewController = CommunityDetailViewController()
         self.window?.makeKeyAndVisible()
     }
 

--- a/ReptileHub/SceneDelegate.swift
+++ b/ReptileHub/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         
-        self.window?.rootViewController = CommunityDetailViewController()
+        self.window?.rootViewController = TabbarViewController()
         self.window?.makeKeyAndVisible()
     }
 

--- a/ReptileHub/View/Community/AddPostView.swift
+++ b/ReptileHub/View/Community/AddPostView.swift
@@ -1,0 +1,23 @@
+//
+//  AddPostView.swift
+//  ReptileHub
+//
+//  Created by 조성빈 on 8/23/24.
+//
+
+import UIKit
+
+class AddPostView: UIView {
+    
+//    private let imagePicker: UIImagePickerController = UIImagePickerController
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+}

--- a/ReptileHub/View/Community/CommentTableViewCell.swift
+++ b/ReptileHub/View/Community/CommentTableViewCell.swift
@@ -28,7 +28,6 @@ class CommentTableViewCell: UITableViewCell {
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
         // Configure the view for the selected state
     }
     
@@ -128,7 +127,6 @@ class CommentTableViewCell: UITableViewCell {
         setupProfileImage()
         setupMenuButton()
         setupElementStackView()
-        print("elementstackview 너비 : \(elementStackView.frame.width)")
     }
 
 }

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -9,8 +9,11 @@ import UIKit
 import SnapKit
 
 class CommunityDetailView: UIView {
-
+    
     var dummyData = ["동해물과 백두산이 마르도 닳도록 하느님이 보우하사 우리나라 만세. 무궁화 삼천리 화려강산 대한사람 대한으로 부디 보전하세.", "커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~", "링딩동", "다크초코 6.7만 달성~", "커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~",]
+    
+    // 키보드 탭 제스쳐
+    lazy var tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapHandler))
     
     // 스크롤 뷰
     private let scrollView: UIScrollView = UIScrollView()
@@ -73,7 +76,7 @@ class CommunityDetailView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-
+        
         setupCommentStackView()
         setupMainScrollView()
         setupProfileImage()
@@ -86,12 +89,75 @@ class CommunityDetailView: UIView {
         setupCountInfoStackView()
         setupDivisionThickLine()
         setupCommentTableView()
+        
+        self.addGestureRecognizer(tapGesture)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardAction),
+                                               name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardAction),
+                                               name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+    
+    // super view 클릭시 키보드 내려감
+    @objc
+    func tapHandler(_ sender: UIView) {
+        commentTextView.resignFirstResponder()
+    }
+    
+    @objc
+    func keyboardAction(_ notification: NSNotification) {
+        guard let keyboardSize = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let animationDuration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+              let animationCurveRawNSN = notification.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber else {
+            return
+        }
+        
+        let animationCurveRaw = animationCurveRawNSN.uintValue
+        let animationCurve = UIView.AnimationOptions(rawValue: animationCurveRaw)
+        
+        switch notification.name {
+        case UIResponder.keyboardWillShowNotification:
+            print("키보드 열림")
+            
+            // 제약조건 변경과 애니메이션을 적용
+            UIView.animate(withDuration: animationDuration, delay: 0, options: animationCurve, animations: {
 
+                self.commentBackgroundView.snp.remakeConstraints { make in
+                    make.width.equalTo(self.frame.width)
+                    make.height.greaterThanOrEqualTo(40)
+                    make.leading.trailing.equalTo(self)
+                    make.bottom.equalTo(self.snp.bottom).offset(-keyboardSize.height)
+                }
+                
+                // 레이아웃 변화를 애니메이션으로 적용
+                self.layoutIfNeeded()
+            }, completion: nil)
+            
+        case UIResponder.keyboardWillHideNotification:
+            print("키보드 닫힘")
+            
+            // 제약조건 변경과 애니메이션을 적용
+            UIView.animate(withDuration: animationDuration, delay: 0, options: animationCurve, animations: {
+                
+                self.commentBackgroundView.snp.remakeConstraints { make in
+                    make.width.equalTo(self.frame.width)
+                    make.height.greaterThanOrEqualTo(40)
+                    make.leading.trailing.equalTo(self)
+                    make.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom)
+                }
+                
+                // 레이아웃 변화를 애니메이션으로 적용
+                self.layoutIfNeeded()
+            }, completion: nil)
+            
+        default:
+            return
+        }
+    }
+    
     
     //MARK: - 스크롤뷰 세팅
     private func setupMainScrollView() {
@@ -234,7 +300,7 @@ class CommunityDetailView: UIView {
         imageStackView.snp.makeConstraints { make in
             make.top.leading.trailing.bottom.equalTo(imageScrollView)
         }
-
+        
         for i in 0..<contentImages.count {
             let imageView: UIView = UIView(frame: CGRect(x: 0, y: 0, width: self.frame.width, height: 230))
             
@@ -258,10 +324,10 @@ class CommunityDetailView: UIView {
                 make.height.equalTo(230)
                 make.width.equalTo(imageScrollView)
             }
-
+            
         }
         
-
+        
     }
     
     //MARK: - 본문 이미지의 페이지 현황
@@ -352,7 +418,7 @@ class CommunityDetailView: UIView {
         headerView.backgroundColor = .yellow
         headerView.frame = CGRect(x: 0, y: 0, width: 0, height: 40)
         
-
+        
         commentTableView.register(CommentTableViewCell.self, forCellReuseIdentifier: "commentCell")
         commentTableView.isScrollEnabled = false
         commentTableView.backgroundColor = .lightGray
@@ -380,7 +446,7 @@ class CommunityDetailView: UIView {
         }
     }
     
-
+    
     
     //MARK: - 댓글 작성란 setup
     private func setupCommentStackView() {
@@ -424,7 +490,8 @@ class CommunityDetailView: UIView {
             make.leading.equalTo(commentBackgroundView.snp.leading).offset(10)
             make.trailing.equalTo(sendButton.snp.leading)
             make.bottom.equalTo(commentBackgroundView.snp.bottom).offset(-5)
-            make.height.greaterThanOrEqualTo(30) // 최소 높이를 30으로 설정
+            make.height.greaterThanOrEqualTo(40) // 최소 높이를 40으로 설정
+            make.height.lessThanOrEqualTo(103)
             make.width.equalTo(342)
         }
         
@@ -504,7 +571,6 @@ class CommunityDetailView: UIView {
         
         if textView.text == "" {
             placeHolder.textColor = .white
-            textView.layoutIfNeeded()
         } else {
             placeHolder.textColor = .clear
         }

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -1,0 +1,546 @@
+//
+//  CommunityDetailView.swift
+//  ReptileHub
+//
+//  Created by 조성빈 on 8/22/24.
+//
+
+import UIKit
+import SnapKit
+
+class CommunityDetailView: UIView {
+
+    var dummyData = ["동해물과 백두산이 마르도 닳도록 하느님이 보우하사 우리나라 만세. 무궁화 삼천리 화려강산 대한사람 대한으로 부디 보전하세.", "커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~", "링딩동", "다크초코 6.7만 달성~", "커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~커뮤니티 상세 페이지 댓글 테이블 뷰 동적 크기 조절. 테이블 뷰 내의 셀들의 높이가 각각 달라지는 상황에서 테이블 뷰를 스크롤되지않고, 셀들의 크기의 합을 테이블 뷰 높이의 합으로 가져가면서 테이블 뷰가 아닌 스크롤 뷰에서 스크롤 할 수 있도록 구현하고싶다..~~",]
+    
+    // 스크롤 뷰
+    private let scrollView: UIScrollView = UIScrollView()
+    private let stackView: UIStackView = UIStackView()
+    
+    // 상단 게시글 정보
+    private let profileImage: UIImageView = UIImageView()
+    
+    private let titleLabel: UILabel = UILabel()
+    private let nicknameLabel: UILabel = UILabel()
+    private let timestampLabel: UILabel = UILabel()
+    private let elementStackView: UIStackView = UIStackView()
+    
+    private let likeButton: UIButton = UIButton()
+    
+    private var menuButton: UIBarButtonItem = UIBarButtonItem()
+    
+    private let titleStackView: UIStackView = UIStackView()
+    
+    // 상단 게시글 정보와 게시글 본문 사이의 구분선
+    private let divisionLine: UIView = UIView()
+    
+    // 본문 이미지
+    private let contentImages: [UIImageView] = [
+        UIImageView(image: UIImage(named: "choba")),
+        UIImageView(image: UIImage(named: "cookie")),
+        UIImageView(image: UIImage(named: "cookie")),
+    ]
+    private var imageViews: [UIView] = []
+    private let imageStackView: UIStackView = UIStackView()
+    private let imageScrollView: UIScrollView = UIScrollView()
+    // 이미지 개수 나타내는 UI
+    private let imagePageCount: UILabel = UILabel()
+    private let pageCountView: UIView = UIView()
+    
+    // 본문 텍스트
+    private let contentText: UILabel = UILabel()
+    
+    // 좋아요, 댓글 개수
+    private let likeCount: UILabel = UILabel()
+    private let commentCount: UILabel = UILabel()
+    private let countInfoStackView: UIStackView = UIStackView()
+    
+    // 본문과 댓글 구분선
+    private let divisionThickLine: UIView = UIView()
+    
+    // 댓글 부분
+    private let commentTableView: UITableView = UITableView(frame: .zero)
+    
+    // 댓글의 높이를 계산하기위한 변수
+    private var tableViewHeight: CGFloat = 0.0
+    private var rowHeights: [IndexPath: CGFloat] = [:]
+    
+    // 댓글 작성란
+    private let commentBackgroundView: UIView = UIView()
+    private let commentTextView: UITextView = UITextView()
+    private let sendButton: UIButton = UIButton()
+    private let placeHolder: UILabel = UILabel()
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupCommentStackView()
+        setupMainScrollView()
+        setupProfileImage()
+        setupElementStackView()
+        setupTitleStackView()
+        setupDivisionLine()
+        setupImageScrollView()
+        setupImagePageCountLabel()
+        setupTextView()
+        setupCountInfoStackView()
+        setupDivisionThickLine()
+        setupCommentTableView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    
+    //MARK: - 스크롤뷰 세팅
+    private func setupMainScrollView() {
+        scrollView.alwaysBounceVertical = true
+        scrollView.backgroundColor = .green
+        
+        stackView.axis = .vertical
+        stackView.distribution = .equalCentering
+        stackView.alignment = .firstBaseline
+        stackView.backgroundColor = .red
+        
+        self.addSubview(scrollView)
+        
+        scrollView.addSubview(stackView)
+        
+        scrollView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalTo(self.safeAreaLayoutGuide)
+            make.bottom.equalTo(commentBackgroundView.snp.top)
+            make.width.equalTo(self.frame.width)
+        }
+        
+        stackView.snp.makeConstraints { make in
+            make.top.leading.trailing.bottom.equalTo(scrollView.contentLayoutGuide)
+            make.width.equalTo(scrollView.snp.width)
+        }
+        
+        let stackViewHeight = stackView.heightAnchor.constraint(greaterThanOrEqualTo: self.heightAnchor)
+        stackViewHeight.priority = .defaultLow
+        stackViewHeight.isActive = true
+    }
+    
+    //MARK: - 프로필 이미지
+    private func setupProfileImage() {
+        profileImage.image = UIImage(systemName: "person")
+        profileImage.backgroundColor = .green
+        profileImage.layer.cornerRadius = 30
+        profileImage.clipsToBounds = true
+    }
+    
+    //MARK: - 제목, 닉네임, 시간 StackView(elementStackView)
+    private func setupElementStackView() {
+        titleLabel.text = "공부는 최대한 미뤄라."
+        titleLabel.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        nicknameLabel.text = "공부싫어"
+        nicknameLabel.font = UIFont.systemFont(ofSize: 12, weight: .regular)
+        timestampLabel.text = "24.08.09 17:31"
+        timestampLabel.font = UIFont.systemFont(ofSize: 10, weight: .light)
+        timestampLabel.textColor = UIColor.lightGray
+        
+        elementStackView.axis = .vertical
+        elementStackView.distribution = .fillEqually
+        elementStackView.alignment = .leading
+        elementStackView.backgroundColor = .systemPink
+        
+        elementStackView.addArrangedSubview(titleLabel)
+        elementStackView.addArrangedSubview(nicknameLabel)
+        elementStackView.addArrangedSubview(timestampLabel)
+    }
+    
+    
+    //MARK: - title StackView + 좋아요 버튼
+    private func setupTitleStackView() {
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        let heartImage = UIImage(systemName: "heart", withConfiguration: imageConfig)
+        
+        likeButton.setImage(heartImage, for: .normal)
+        
+        likeButton.snp.makeConstraints { make in
+            make.width.equalTo(40)
+        }
+        
+        titleStackView.axis = .horizontal
+        titleStackView.distribution = .fill
+        titleStackView.alignment = .center
+        titleStackView.spacing = 10
+        titleStackView.backgroundColor = .yellow
+        
+        titleStackView.addArrangedSubview(profileImage)
+        titleStackView.addArrangedSubview(elementStackView)
+        titleStackView.addArrangedSubview(likeButton)
+        
+        self.stackView.addArrangedSubview(titleStackView)
+        
+        titleStackView.snp.makeConstraints { make in
+            make.top.equalTo(self.stackView.snp.top)
+            make.leading.equalTo(self.stackView.snp.leading).offset(24)
+            make.trailing.equalTo(self.stackView.snp.trailing).offset(-24)
+            make.height.equalTo(60)
+        }
+        
+        profileImage.snp.makeConstraints { make in
+            make.height.width.equalTo(60)
+            make.leading.equalTo(titleStackView.snp.leading)
+        }
+        
+        elementStackView.snp.makeConstraints { make in
+            make.leading.equalTo(profileImage.snp.trailing).offset(10)
+            make.trailing.equalTo(titleStackView.snp.trailing)
+            make.height.equalTo(50)
+        }
+    }
+    
+    //MARK: - 제목, 본문과의 구분선
+    private func setupDivisionLine() {
+        divisionLine.backgroundColor = .lightGray
+        
+        self.stackView.addArrangedSubview(divisionLine)
+        
+        divisionLine.snp.makeConstraints { make in
+            make.height.equalTo(0.5)
+            make.top.equalTo(titleStackView.snp.bottom).offset(12)
+            make.leading.equalTo(self.stackView.snp.leading)
+            make.trailing.equalTo(self.stackView.snp.trailing)
+        }
+    }
+    
+    //MARK: - 본문 이미지, 스크롤뷰
+    private func setupImageScrollView() {
+        imageStackView.axis = .horizontal
+        imageStackView.distribution = .fillEqually
+        imageStackView.alignment = .center
+        imageStackView.backgroundColor = .green
+        
+        imageScrollView.alwaysBounceHorizontal = true
+        imageScrollView.isPagingEnabled = true
+        imageScrollView.backgroundColor = .blue
+        
+        self.stackView.addArrangedSubview(imageScrollView)
+        
+        imageScrollView.snp.makeConstraints { make in
+            make.height.equalTo(230)
+            make.width.equalTo(self)
+            make.top.equalTo(divisionLine.snp.bottom).offset(12)
+            make.leading.equalTo(self.stackView.snp.leading)
+            make.trailing.equalTo(self.stackView.snp.trailing)
+        }
+        
+        imageScrollView.addSubview(imageStackView)
+        
+        imageStackView.snp.makeConstraints { make in
+            make.top.leading.trailing.bottom.equalTo(imageScrollView)
+        }
+
+        for i in 0..<contentImages.count {
+            let imageView: UIView = UIView(frame: CGRect(x: 0, y: 0, width: self.frame.width, height: 230))
+            
+            contentImages[i].contentMode = .scaleAspectFit
+            
+            imageView.addSubview(contentImages[i])
+            
+            contentImages[i].snp.makeConstraints { make in
+                make.centerX.equalTo(imageView)
+                make.height.equalTo(230)
+            }
+            
+            imageViews.append(imageView)
+        }
+        
+        for imageView in imageViews {
+            imageView.backgroundColor = .gray
+            imageStackView.addArrangedSubview(imageView)
+            
+            imageView.snp.makeConstraints { make in
+                make.height.equalTo(230)
+                make.width.equalTo(imageScrollView)
+            }
+
+        }
+        
+
+    }
+    
+    //MARK: - 본문 이미지의 페이지 현황
+    private func setupImagePageCountLabel() {
+        pageCountView.backgroundColor = .lightGray
+        pageCountView.layer.cornerRadius = 12
+        
+        pageCountView.addSubview(imagePageCount)
+        
+        self.stackView.addArrangedSubview(pageCountView)
+        
+        pageCountView.snp.makeConstraints { make in
+            make.height.equalTo(27)
+            make.width.equalTo(40)
+            make.trailing.equalTo(imageScrollView.snp.trailing).offset(-10)
+            make.bottom.equalTo(imageScrollView.snp.bottom).offset(-10)
+        }
+        
+        imagePageCount.text = "1/\(contentImages.count)"
+        imagePageCount.backgroundColor = .lightGray
+        
+        imagePageCount.snp.makeConstraints { make in
+            make.centerX.equalTo(pageCountView)
+            make.centerY.equalTo(pageCountView)
+        }
+    }
+    
+    //MARK: - 본문 내용
+    private func setupTextView() {
+        contentText.text = "게시글 본문 예시 내용입니다."
+        contentText.font = UIFont.systemFont(ofSize: 14, weight: .medium)
+        contentText.backgroundColor = .lightGray
+        
+        self.stackView.addArrangedSubview(contentText)
+        
+        contentText.snp.makeConstraints { make in
+            make.top.equalTo(imageScrollView.snp.bottom).offset(10)
+            make.leading.trailing.equalTo(titleStackView)
+            make.height.greaterThanOrEqualTo(80)
+        }
+    }
+    
+    //MARK: - count info stackview - 좋아요, 댓글 수 스택뷰
+    private func setupCountInfoStackView() {
+        let likeImage = UIImageView(image: UIImage(systemName: "heart"))
+        let commentImage = UIImageView(image: UIImage(systemName: "message"))
+        
+        countInfoStackView.axis = .horizontal
+        countInfoStackView.distribution = .fill
+        countInfoStackView.spacing = 5
+        countInfoStackView.alignment = .center
+        
+        likeCount.text = "123"
+        commentCount.text = "123"
+        
+        countInfoStackView.addArrangedSubview(likeImage)
+        countInfoStackView.addArrangedSubview(likeCount)
+        countInfoStackView.addArrangedSubview(commentImage)
+        countInfoStackView.addArrangedSubview(commentCount)
+        
+        self.stackView.addArrangedSubview(countInfoStackView)
+        
+        countInfoStackView.snp.makeConstraints { make in
+            make.top.equalTo(contentText.snp.bottom).offset(10)
+            make.leading.equalTo(contentText.snp.leading)
+            make.height.equalTo(20)
+        }
+    }
+    
+    //MARK: - 본문과 댓글 사이의 구분선(두꺼움)
+    private func setupDivisionThickLine() {
+        divisionThickLine.backgroundColor = .lightGray
+        
+        self.stackView.addArrangedSubview(divisionThickLine)
+        
+        divisionThickLine.snp.makeConstraints { make in
+            make.height.equalTo(10)
+            make.top.equalTo(countInfoStackView.snp.bottom).offset(10)
+            make.leading.trailing.equalTo(self)
+            
+        }
+    }
+    
+    //MARK: - 댓글 테이블 뷰
+    private func setupCommentTableView() {
+        let headerView: UILabel = UILabel()
+        headerView.text = "댓글"
+        headerView.backgroundColor = .yellow
+        headerView.frame = CGRect(x: 0, y: 0, width: 0, height: 40)
+        
+
+        commentTableView.register(CommentTableViewCell.self, forCellReuseIdentifier: "commentCell")
+        commentTableView.isScrollEnabled = false
+        commentTableView.backgroundColor = .lightGray
+        commentTableView.estimatedRowHeight = 60
+        commentTableView.rowHeight = UITableView.automaticDimension
+        commentTableView.tableHeaderView = headerView
+        
+        self.stackView.addArrangedSubview(commentTableView)
+        
+        commentTableView.translatesAutoresizingMaskIntoConstraints = false
+        
+        var resultHeight: CGFloat = 0.0
+        
+        for comment in dummyData {
+            let height = getLabelHeight(tableView: commentTableView,text: comment)
+            resultHeight += height
+        }
+        
+        commentTableView.snp.makeConstraints { make in
+            make.top.equalTo(divisionThickLine.snp.bottom)
+            make.leading.equalTo(self.stackView.snp.leading).offset(24)
+            make.trailing.equalTo(self.stackView.snp.trailing).offset(-24)
+            make.bottom.equalTo(self.stackView.snp.bottom)
+            make.height.equalTo(resultHeight)
+        }
+    }
+    
+
+    
+    //MARK: - 댓글 작성란 setup
+    private func setupCommentStackView() {
+        commentTextView.layer.cornerRadius = 10
+        commentTextView.font = UIFont.systemFont(ofSize: 18)
+        commentTextView.isScrollEnabled = false
+        commentTextView.textContainer.lineFragmentPadding = 15
+        commentTextView.backgroundColor = .lightGray
+        
+        placeHolder.text = "댓글을 남겨보세요"
+        placeHolder.font = UIFont.systemFont(ofSize: 18, weight: .light)
+        placeHolder.textColor = .white
+        
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 25)
+        let planeImage = UIImage(systemName: "paperplane.fill", withConfiguration: imageConfig)
+        sendButton.setImage(planeImage, for: .normal)
+        
+        commentBackgroundView.backgroundColor = .gray
+        
+        self.addSubview(commentBackgroundView)
+        
+        commentBackgroundView.snp.makeConstraints { make in
+            make.width.equalTo(self.frame.width)
+            make.height.greaterThanOrEqualTo(40)
+            make.leading.trailing.equalTo(self)
+            make.bottom.equalTo(self.safeAreaLayoutGuide.snp.bottom)
+        }
+        
+        commentBackgroundView.addSubview(commentTextView)
+        commentBackgroundView.addSubview(sendButton)
+        commentTextView.addSubview(placeHolder)
+        
+        sendButton.snp.makeConstraints { make in
+            make.trailing.equalTo(commentBackgroundView.snp.trailing)
+            make.bottom.equalTo(commentBackgroundView.snp.bottom).offset(-3)
+            make.height.width.equalTo(40)
+        }
+        
+        commentTextView.snp.makeConstraints { make in
+            make.top.equalTo(commentBackgroundView.snp.top).offset(5)
+            make.leading.equalTo(commentBackgroundView.snp.leading).offset(10)
+            make.trailing.equalTo(sendButton.snp.leading)
+            make.bottom.equalTo(commentBackgroundView.snp.bottom).offset(-5)
+            make.height.greaterThanOrEqualTo(30) // 최소 높이를 30으로 설정
+            make.width.equalTo(342)
+        }
+        
+        placeHolder.snp.makeConstraints { make in
+            make.centerY.equalTo(commentTextView)
+            make.leading.equalTo(commentTextView.snp.leading).offset(15)
+        }
+    }
+    
+    //MARK: - UILabel의 높이를 측정하는 메서드
+    func getLabelHeight(tableView: UITableView, text: String) -> CGFloat {
+        let label = UILabel(
+            frame: .init(
+                x: .zero,
+                y: .zero,
+                width: tableView.frame.width - 75,
+                height: .greatestFiniteMagnitude
+            )
+        )
+        label.text = text
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 13)
+        label.sizeToFit()
+        let labelHeight = label.frame.height
+        return labelHeight
+    }
+    
+    func remakeTableView() {
+        // 뷰가 나타나고 셀의 크기를 취합하여 테이블 뷰의 레이아웃(높이)를 다시 잡음.
+        commentTableView.snp.remakeConstraints { make in
+            make.top.equalTo(divisionThickLine.snp.bottom)
+            make.leading.equalTo(self.stackView.snp.leading).offset(24)
+            make.trailing.equalTo(self.stackView.snp.trailing).offset(-24)
+            make.bottom.equalTo(self.stackView.snp.bottom)
+            make.height.equalTo(tableViewHeight + 40) // 40은 위ㅔㅇ서 지정한 테이블뷰-헤더뷰 크기임.
+        }
+    }
+    
+    func initHeightValue() {
+        // 뷰가 나타날 때 해당 값들을 초기화함.
+        tableViewHeight = 0.0
+        rowHeights = [:]
+    }
+    
+    // UIScrollViewDelegate의 scrollViewDidScroll에 사용
+    func imageScrollCount(scrollView: UIScrollView) {
+        guard scrollView.frame.width > 0 else {
+            print("0")
+            return
+        }
+        let pageIndex = round(scrollView.contentOffset.x / scrollView.frame.width)
+        print(round(scrollView.contentOffset.x))
+        print(scrollView.frame.width)
+        self.imagePageCount.text = "\(Int(pageIndex) + 1)/\(self.contentImages.count)"
+    }
+    
+    // UITableView의 heightForRowAt에 사용
+    func tableViewCellHeight(indexPath: IndexPath, tableView: UITableView) -> CGFloat {
+        if let cachedHeight = rowHeights[indexPath] {
+            return cachedHeight
+        }
+        
+        let labelHeight = getLabelHeight(tableView: tableView, text: dummyData[indexPath.row])
+        
+        // 50 = cell의 commentLabel의 버티컬 패딩 값 조절을 위한 값 / 증가(패딩 증가) / 감소(패딩 감소)
+        tableViewHeight += (labelHeight + 50)
+        rowHeights[indexPath] = labelHeight + 50
+        return labelHeight
+    }
+    
+    // UITextViewDelegate의 textViewDidChange에 사용
+    func textViewChange(textView: UITextView) {
+        let size = CGSize(width: commentTextView.frame.width, height: .greatestFiniteMagnitude)
+        let estimatedSize = textView.sizeThatFits(size)
+        
+        print("현재 텍스트뷰 높이 : \(estimatedSize.height), \(estimatedSize.width)")
+        
+        if textView.text == "" {
+            placeHolder.textColor = .white
+            textView.layoutIfNeeded()
+        } else {
+            placeHolder.textColor = .clear
+        }
+        
+        if estimatedSize.height > 102 {
+            textView.isScrollEnabled = true
+            
+            textView.constraints.forEach { constraint in
+                if constraint.firstAttribute == .height {
+                    constraint.constant = 102
+                }
+            }
+        } else {
+            textView.isScrollEnabled = false
+            textView.constraints.forEach { constraint in
+                if constraint.firstAttribute == .height {
+                    constraint.constant = estimatedSize.height
+                }
+            }
+        }
+        
+        // textView 18 Font 기준
+        // 1줄 - 37.6666
+        // 2줄 - 59.0
+        // 3줄 - 80.6666
+        // 4줄 - 102.0
+    }
+    
+    func configureTableView(scrollViewDelegate: UIScrollViewDelegate, tableViewDelegate: UITableViewDelegate, tableViewDatasource: UITableViewDataSource, textViewDelegate: UITextViewDelegate) {
+        imageScrollView.delegate = scrollViewDelegate
+        
+        commentTableView.delegate = tableViewDelegate
+        commentTableView.dataSource = tableViewDatasource
+        
+        commentTextView.delegate = textViewDelegate
+    }
+    
+    
+}

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -15,6 +15,10 @@ class CommunityDetailView: UIView {
     // 키보드 탭 제스쳐
     lazy var tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapHandler))
     
+    // 키보드 델리겟 매니저
+    let keyboardManager = KeyboardManager()
+    
+    
     // 스크롤 뷰
     private let scrollView: UIScrollView = UIScrollView()
     private let stackView: UIStackView = UIStackView()
@@ -74,15 +78,15 @@ class CommunityDetailView: UIView {
     private let placeHolder: UILabel = UILabel()
     
     
-    let keyboardManager = KeyboardManager()
-    
-    
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        // 제스처 적용(슈퍼뷰 클릭시 키보드 내려감)
         self.addGestureRecognizer(tapGesture)
         
+        // 키보드 델리겟 매니저
+        // showNoti : 키보드 나올 때 Notification
+        // hideNoti : 키보드 내려갈 때 Notification
         keyboardManager.delegate = self
         keyboardManager.showNoti()
         keyboardManager.hideNoti()

--- a/ReptileHub/View/Community/CommunityListView.swift
+++ b/ReptileHub/View/Community/CommunityListView.swift
@@ -21,8 +21,6 @@ class CommunityListView: UIView {
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setupTableView()
-        setupAddButton()
     }
     
     //MARK: - communityTableView set up

--- a/ReptileHub/View/Community/CommunityListView.swift
+++ b/ReptileHub/View/Community/CommunityListView.swift
@@ -23,6 +23,8 @@ class CommunityListView: UIView {
         super.init(coder: coder)
     }
     
+
+    
     //MARK: - communityTableView set up
     private func setupTableView() {
         communityTableView.backgroundColor = .yellow

--- a/ReptileHub/View/Community/CommunityTableViewCell.swift
+++ b/ReptileHub/View/Community/CommunityTableViewCell.swift
@@ -51,7 +51,7 @@ class CommunityTableViewCell: UITableViewCell {
     }
     
     //MARK: - Thumnail Image
-    func setupThumbnail() {
+    private func setupThumbnail() {
         thumbnailImageView.image = UIImage(systemName: "camera")
         thumbnailImageView.contentMode = .scaleAspectFit
         thumbnailImageView.layer.cornerRadius = 5
@@ -68,7 +68,7 @@ class CommunityTableViewCell: UITableViewCell {
     }
     
     //MARK: - 제목, 내용 StackView
-    func setupMainInfoStackView() {
+    private func setupMainInfoStackView() {
         mainInfoStackView.axis = .vertical
         mainInfoStackView.distribution = .equalSpacing
         mainInfoStackView.alignment = .leading
@@ -95,7 +95,7 @@ class CommunityTableViewCell: UITableViewCell {
     }
     
     //MARK: - 댓글, 좋아요 수, 닉네임, 게시날짜 stackview
-    func setupSubInfoStackView() {
+    private func setupSubInfoStackView() {
         // 댓글, 좋아요 이미지와 count 스택뷰
         firstStackView.axis = .horizontal
         firstStackView.distribution = .equalSpacing
@@ -147,7 +147,7 @@ class CommunityTableViewCell: UITableViewCell {
     }
     
     //MARK: - menu 버튼
-    func setupMenuButton() {
+    private func setupMenuButton() {
         menuButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
         menuButton.contentMode = .scaleAspectFit
         menuButton.transform = CGAffineTransform(rotationAngle: .pi * 0.5)

--- a/ReptileHub/View/Community/KeyboardDelegate.swift
+++ b/ReptileHub/View/Community/KeyboardDelegate.swift
@@ -1,0 +1,84 @@
+//
+//  KeyboardProtocol.swift
+//  ReptileHub
+//
+//  Created by 조성빈 on 8/25/24.
+//
+
+import Foundation
+import UIKit
+
+
+protocol KeyboardNotificationDelegate: AnyObject {
+    //================================================//
+    func keyboardWillShow(keyboardSize: CGRect)
+    func keyboardWillHide(keyboardSize: CGRect)
+    // keyboardAction() 내부에서 키보드가 올라올 때, 내려갈 때의 레이아웃 들을 정의해주시면 됩니다! (extension으로)
+    // 애니메이션을 적용해야해서 위 두가지의 메서드를 정의하고 마지막에 self.layoutIfNeeded() 를 넣어주세요!
+    // (self.layoutIfNeeded()는 UIView에서만 사용할 수 있어서 따로 불러오셔야합니다..)
+    //================================================//
+}
+
+class KeyboardManager {
+    
+    //================================================//
+    // 델리게이트 변수
+    weak var delegate: KeyboardNotificationDelegate?
+    
+    
+    // 키보드 나옴/숨김 NotificationCenter
+    func showNoti() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardAction),
+                                               name: UIResponder.keyboardWillShowNotification, object: nil)
+    }
+    
+    func hideNoti() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardAction),
+                                               name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    // delgate, showNoti(), hideNoti() 이 세 가지는 viewDidLoad() 내부에 있어야합니다~
+    //================================================//
+    
+    //================================================//
+    // 키보드가 올라옴에 따라 뷰를 움직이는 것이기 때문에 ViewController가 아닌 View에 extension으로
+    // 원하는 레이아웃을 잡아주시면 됩니다~!
+    @objc
+    private func keyboardAction(_ notification: NSNotification) {
+        guard let keyboardSize = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+              let animationDuration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double,
+              let animationCurveRawNSN = notification.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? NSNumber else {
+            return
+        }
+        
+        let animationCurveRaw = animationCurveRawNSN.uintValue
+        let animationCurve = UIView.AnimationOptions(rawValue: animationCurveRaw)
+        
+        switch notification.name {
+        case UIResponder.keyboardWillShowNotification:
+            print("키보드 열림")
+            
+            UIView.animate(withDuration: animationDuration, delay: 0, options: animationCurve, animations: {
+                        
+                // 델리게이트를 통해 메서드 호출
+                self.delegate?.keyboardWillShow(keyboardSize: keyboardSize)
+    
+                    }, completion: nil)
+            
+
+            
+        case UIResponder.keyboardWillHideNotification:
+            print("키보드 닫힘")
+            
+            UIView.animate(withDuration: animationDuration, delay: 0, options: animationCurve, animations: {
+                        
+                // 델리게이트를 통해 메서드 호출
+                self.delegate?.keyboardWillHide(keyboardSize: keyboardSize)
+                
+                    }, completion: nil)
+            
+        default:
+            return
+        }
+    }
+    //================================================//
+}


### PR DESCRIPTION
#  📌    Pull Request 

- 요청(이름) : 조성빈

## :sparkles: PR 내용
- 기능 추가 [v] 
- 기능 삭제 [ ]
- 버그 수정 [ ]

## 🔉  주요 이슈 
 추가/수정/이동한 폴더, 파일 목록 
 - View
ㄴ Community
   ㄴ CommunityDetailView(N)
   ㄴ AddPostView(N)
   ㄴ KeyboardDelegate(N) : 임시 생성(추후 이동 예정)
- Controller
ㄴ Community
   ㄴ AddPostVieController(N)



## 💻  작업내용
- CommunityListView의 'required init' 내부의 메서드 삭제
- CommunityDetailView 댓글 입력창 추가
- CommunityDetailViewController 뷰 분리
- KeyboardDelegate, 키보드 올라옴/내려감에 따른 Notification 및 레이아웃 변경 메서드 프로토콜 생성
  - KeyboardDelegate 내부에 간단한 사용법 주석 추가
  - superView 눌러서 키보드 내려가는 것은 별개로 생성해야함
  - (참고 : 키보드에 따라 '레이아웃'이 변경되어 extension은 View 내부에 써두었음)


## 문제발생/해결
| 댓글 입력창 목표 UI | 
|----------|
| <img width = "250" alt = "No Data Image" src = "https://github.com/user-attachments/assets/2e45bb33-5094-4472-b0cc-6fec64579e49"> |
1. StackView 안에 TextView와 Button을 넣어 구현하려는데 레이아웃을 아무리 수정해봐도 TextView의 높이가 변하질 않음
  - [해결] StackView -> UIView 변경, TextView의 isScrollEnabled 사용하여 높이 변경 O

2. 완성된 댓글 입력창을 DetailView에 이식한(ScrollView 아래) 상태이고 키보드의 유무에 따라 뷰가 올라가도록 해보았지만 댓글 입력창이 스크롤뷰에 가려져 보이지 않음
  - [실패] 댓글 입력창이 키보드와 함께 올라가는만큼 ScrollView의 높이를 줄여봄 -> ScrollView는 이상 없으나, 댓글 입력창의 TextView  의 높이가 깨짐
  - [실패] 댓글 입력창과 ScrollView를 동시에 올려봄 -> ScrollView가 올라갈 때 view.safearea를 침범함
  - [해결] 뷰를 올려버리는게 아니라, 댓글 입력창의 bottom을 self.safearealayoutguide.snp.bottom에서 self.snp.bottom).offset(-키보드 높이)로 레이아웃 수정함 -> ScrollView의 bottom이 댓글 입력창의 top과 연결되어있어서 알아서 줄었다 늘었다 가능


## 📷  스크린샷/영상
- 완성된 댓글 입력창 UI
<img width = "250" alt = "No Data Image" src = "https://github.com/user-attachments/assets/4d96b64f-5c9b-4b4c-a0a7-e901bf873b69">


