### PR TITLE
Feature/Service - 로그인 Flow 변경, fetch 할때 에러나는 부분 해결 및 이미지 옵셔널 가능하도록 수정 

### DIFF
--- a/ReptileHub.xcodeproj/project.pbxproj
+++ b/ReptileHub.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		589CCFFF2C608FFF00812D17 /* CommunityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */; };
 		589CD0012C60901500812D17 /* GrowthDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */; };
 		58C61A042C7A530F00E1FD3A /* KeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C61A032C7A530F00E1FD3A /* KeyboardDelegate.swift */; };
-		58CD8FC52C8232ED0009CE9C /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 58CD8FC42C8232ED0009CE9C /* Kingfisher */; };
 		58F3F6402C772E6B00FDABD1 /* CommunityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */; };
 		58F3F6422C781DF500FDABD1 /* AddPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6412C781DF500FDABD1 /* AddPostViewController.swift */; };
 		58F3F6442C781F1400FDABD1 /* AddPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6432C781F1400FDABD1 /* AddPostView.swift */; };

--- a/ReptileHub/AppDelegate.swift
+++ b/ReptileHub/AppDelegate.swift
@@ -22,13 +22,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         KakaoSDK.initSDK(appKey:"안알랴줌")
        
         
-        AuthService.shared.addAuthStateDidChangeListener { user in
-            if user != nil {
-                self.showMainViewController()
-            } else {
-                self.showLoginViewController()
-            }
-        }
+//        AuthService.shared.addAuthStateDidChangeListener { user in
+//            if user != nil {
+//                self.showMainViewController()
+//            } else {
+//                self.showLoginViewController()
+//            }
+//        }
         
         return true
     }

--- a/ReptileHub/Controller/Profile/ProfileViewController.swift
+++ b/ReptileHub/Controller/Profile/ProfileViewController.swift
@@ -22,6 +22,7 @@ class ProfileViewController: UIViewController {
         guard let uid = Auth.auth().currentUser?.uid else {return}
         
         UserService.shared.fetchUserProfile(uid: uid) { results in
+           print("지금 프로필 검색 uid -\(uid)") 
             switch results {
                 
             case .success(let profile):

--- a/ReptileHub/Controller/Profile/ProfileViewController.swift
+++ b/ReptileHub/Controller/Profile/ProfileViewController.swift
@@ -18,6 +18,21 @@ class ProfileViewController: UIViewController {
     override func loadView() {
         super.viewDidLoad()
         
+        
+        guard let uid = Auth.auth().currentUser?.uid else {return}
+        
+        UserService.shared.fetchUserProfile(uid: uid) { results in
+            switch results {
+                
+            case .success(let profile):
+                print("porfile \(profile)")
+            case .failure(let error):
+                print("error \(error.localizedDescription)")
+            }
+        }
+        
+        
+        
         self.navigationItem.title = "프로필"
         
         self.view = profileView

--- a/ReptileHub/Controller/SpecialNote/SpecialEditViewController.swift
+++ b/ReptileHub/Controller/SpecialNote/SpecialEditViewController.swift
@@ -109,3 +109,11 @@ extension SpecialEditViewController: UITextViewDelegate {
 }
 
 
+extension SpecialEditViewController:SpecialEditViewDelegate {
+   
+    func didTapPostButton(imageData: [Data], date: Date, title: String, text: String) {
+        <#code#>
+    }
+    
+    
+}

--- a/ReptileHub/Controller/TabbarViewController.swift
+++ b/ReptileHub/Controller/TabbarViewController.swift
@@ -21,9 +21,7 @@ class TabbarViewController: UITabBarController {
             print("currentUser -----  \(user.uid)")
         }
 
-        if let user = Auth.auth().currentUser {
-            print("currentUser -----  \(user.uid)")
-        }
+    
 
         let firstNavigationController = UINavigationController(rootViewController: communityVC)
         let secondNavigationController = UINavigationController(rootViewController: diaryVC)

--- a/ReptileHub/Model/AuthUser.swift
+++ b/ReptileHub/Model/AuthUser.swift
@@ -15,6 +15,9 @@ protocol AuthUser {
     var email: String? { get }
     var name: String? { get }
     var loginType: String { get }
+    var idToken: String? { get }
+    var accessToken: String? { get }
+    var providerUID: String { get }
 }
 
 // GoogleAuthUser 클래스 정의
@@ -23,11 +26,17 @@ struct GoogleAuthUser: AuthUser {
     let uid: String
     let email: String?
     let name: String?
+    let idToken: String?
+    let accessToken: String?
+    let providerUID: String
 
     init(user: GIDGoogleUser) {
         self.uid = user.userID ?? ""
         self.email = user.profile?.email
         self.name = user.profile?.name
+        self.idToken = user.idToken?.tokenString
+        self.accessToken = user.accessToken.tokenString
+        self.providerUID = user.userID ?? ""
         self.loginType = "Google"
     }
 }
@@ -38,11 +47,16 @@ struct AppleAuthUser: AuthUser {
     let uid: String
     let email: String?
     let name: String?
+    let idToken: String? //
+    let accessToken: String? = nil
+    let providerUID: String
 
     init(credential: ASAuthorizationAppleIDCredential) {
         self.uid = credential.user
         self.email = credential.email
         self.name = credential.fullName?.formatted()
+        self.idToken = String(data: credential.identityToken ?? Data(), encoding: .utf8)
+        self.providerUID = credential.user // Apple 고유 사용자 ID
         self.loginType = "Apple"
     }
 }
@@ -53,11 +67,15 @@ struct KakaoAuthUser: AuthUser {
     let uid: String
     let email: String?
     let name: String?
+    let idToken: String? = nil // Kakao는 ID 토큰이 없음
+    let accessToken: String? = nil // Access 토큰
+    let providerUID: String // Kakao 고유 사용자 ID
     
     init(user:KakaoSDKUser.User) {
         self.uid = String(describing: user.id)
         self.email = user.kakaoAccount?.email
         self.name = user.kakaoAccount?.profile?.nickname
+        self.providerUID = String(describing: user.id)
         self.loginType = "Kakao"
     }
 }

--- a/ReptileHub/Model/DiaryModel.swift
+++ b/ReptileHub/Model/DiaryModel.swift
@@ -96,6 +96,7 @@ struct DiaryResponse:Codable {
     let content: String
     let imageURLs: [String]
     let createdAt: Date?
+    let selectedDate: Date?
 }
 
 // 도마뱀 날짜별 무게

--- a/ReptileHub/Model/UserModel.swift
+++ b/ReptileHub/Model/UserModel.swift
@@ -15,6 +15,7 @@ struct BlockUserProfile {
 
 struct UserProfile {
     var uid: String
+    let providerUID: String
     let name: String
     let profileImageURL: String
     let loginType: String

--- a/ReptileHub/SceneDelegate.swift
+++ b/ReptileHub/SceneDelegate.swift
@@ -20,16 +20,20 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         
-        if let currentUser = Auth.auth().currentUser {
-            print("과연 지금 유저는? ---------------  \(currentUser.uid)")
-                    // 유저가 로그인 되어 있는 경우 TabbarViewController 설정
-                    let tabVC = TabbarViewController()
-                    window?.rootViewController = tabVC
-                } else {
-                    // 유저가 로그인 되어 있지 않은 경우 LoginViewController 설정
-                    let loginVC = LoginViewController()
-                    window?.rootViewController = loginVC
-                }
+        let tabVC = SpecialEditViewController()
+        window?.rootViewController = tabVC
+        
+        
+//        if let currentUser = Auth.auth().currentUser {
+//            print("과연 지금 유저는? ---------------  \(currentUser.uid)")
+//                    // 유저가 로그인 되어 있는 경우 TabbarViewController 설정
+//                    let tabVC = TabbarViewController()
+//                    window?.rootViewController = tabVC
+//                } else {
+//                    // 유저가 로그인 되어 있지 않은 경우 LoginViewController 설정
+//                    let loginVC = LoginViewController()
+//                    window?.rootViewController = loginVC
+//                }
         self.window?.makeKeyAndVisible()
     }
 

--- a/ReptileHub/Service/AuthService.swift
+++ b/ReptileHub/Service/AuthService.swift
@@ -25,7 +25,7 @@ class AuthService:NSObject {
     private override init() {}
     
     //MARK: - Google OAuth 로그인
-    func loginWithGoogle(presentingViewController:UIViewController,completion: @escaping (Bool)-> Void) {
+    func loginWithGoogle(presentingViewController:UIViewController, completion: @escaping (Bool)-> Void) {
         guard let clientID = FirebaseApp.app()?.options.clientID else {
             completion(false)
             return
@@ -47,33 +47,17 @@ class AuthService:NSObject {
                 return
             }
             
-            let idToken = user.idToken!.tokenString
-            let accessToken = user.accessToken.tokenString
-            let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
-            print("idToken \(idToken)")
-            print("accessToken \(accessToken)")
+            let googleUser = GoogleAuthUser(user: user)
             
-            Auth.auth().signIn(with: credential) { authResult, error in
-                if let error = error {
-                    print("DEBUG: Firebase Sign In Error: \(error.localizedDescription)")
-                    completion(false)
-                    return
+            // 소셜 로그인 성공 시 Firestore에서 유저 존재 여부 확인
+            self.checkIfUserExists(providerUID: googleUser.uid, loginType: googleUser.loginType) { exists in
+                if exists {
+                    // 이미 유저가 존재하는 경우 바로 로그인 처리
+                    completion(true)
+                } else {
+                    // 유저가 존재하지 않는 경우 약관 동의 뷰로 이동
+                    self.navigateToTermsAgreementView(user: googleUser, presentingViewController: presentingViewController, completion: completion)
                 }
-                
-                guard let uid = authResult?.user.uid else {
-                    completion(false)
-                    return
-                }
-                
-                let googleUser = GoogleAuthUser(user: user)
-                self.checkIfUserExists(uid: uid, email: googleUser.email, name: googleUser.name) { exists in
-                    if exists {
-                        completion(true)
-                    } else {
-                        self.navigateToTermsAgreementView(user: googleUser, presentingViewController: presentingViewController, completion: completion)
-                    }
-                }
-                
             }
         }
     }
@@ -105,10 +89,8 @@ class AuthService:NSObject {
                     self.requestKakaoOauth(presentingViewController: presentingViewController, completion: completion)
                     print("Token error, requesting OAuth")
                 } else {
-                    // 토큰이 유효한 경우 사용자 정보 가져오기
                     print("Token is valid, retrieving user info")
                     self.requestKakaoOauth(presentingViewController: presentingViewController, completion: completion)
-                    
                 }
             }
         } else {
@@ -116,171 +98,192 @@ class AuthService:NSObject {
             self.requestKakaoOauth(presentingViewController: presentingViewController, completion: completion)
         }
     }
-    
 }
 
 //MARK: - FIREBASE 관련 함수들
 extension AuthService {
     // 유저가 회원가입이 되어있는지 검증하는 함수
-    private func checkIfUserExists(uid: String, email: String?, name: String?, completion: @escaping (Bool) -> Void) {
+    private func checkIfUserExists(providerUID: String, loginType: String, completion: @escaping (Bool) -> Void) {
         let db = Firestore.firestore()
-        let docRef = db.collection("users").document(uid)
+        let userRef = db.collection("users").whereField("providerUID", isEqualTo: providerUID)
         
-        docRef.getDocument { document, error in
-            if let document = document, document.exists {
+        userRef.getDocuments { (querySnapshot, error) in
+            if let error = error {
+                print("DEBUG: Error checking user existence: \(error.localizedDescription)")
+                completion(false)
+            } else if querySnapshot?.isEmpty == false {
                 completion(true)
             } else {
-                let defaultProfileImageRef = Storage.storage().reference().child("profile_images/default_profile.jpg")
-                defaultProfileImageRef.downloadURL { url, error in
-                    if let error = error {
-                        print("DEBUG: DefaultProfile Image 에러 발생 - \(error.localizedDescription)")
-                        completion(false)
-                        return
-                    }
-                    guard let downloadURL = url else {
-                        print("DEBUG: Default Profile image URL 없음")
-                        completion(false)
-                        return
-                    }
-                    
-                    let userData: [String: Any] = [
-                        "uid": uid,
-                        "email": email ?? "",
-                        "name": name ?? "",
-                        "profileImageURL": downloadURL.absoluteString
-                    ]
-                    db.collection("users").document(uid).setData(userData) { error in
-                        if let error = error {
-                            print("DEBUG: 유저 데이터 저장 실패 - \(error.localizedDescription)")
-                        } else {
-                            print("유저 정보 저장 성공")
-                        }
-                        completion(false)
-                    }
-                }
+                completion(false)
             }
         }
     }
     
-    // 처음 회원가입 시 약관동의 VIEW 로 이동하는 함수
-    private func navigateToTermsAgreementView(user:AuthUser,presentingViewController:UIViewController,completion:@escaping (Bool)->Void) {
-        let termsVC = TermsAgreementViewController(user:user)
-        termsVC.modalPresentationStyle = .fullScreen
-        termsVC.onAgreementAccepted = {
-            guard let uid = Auth.auth().currentUser?.uid else {
+    
+    // FirebaseAuth에 사용자 등록
+    private func createFirebaseUser(user: AuthUser, completion: @escaping (Bool) -> Void) {
+        let credential: AuthCredential
+        switch user.loginType {
+        case "Google":
+            guard let idToken = user.idToken, let accessToken = user.accessToken else {
+                print("DEBUG: Google Auth Token is missing")
                 completion(false)
                 return
             }
-            self.saveUserWithDefaultProfileImage(uid:uid,user:user) {
+            credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: accessToken)
+        case "Apple":
+            guard let idToken = user.idToken else {
+                print("DEBUG: Apple ID Token is missing")
+                completion(false)
+                return
+            }
+            credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idToken, rawNonce: currentNonce!)
+        case "Kakao":
+            let email = user.email ?? ""
+            let password = user.uid
+            Auth.auth().createUser(withEmail: email, password: password) { result, error in
+                if let error = error {
+                    print("DEBUG: Firebase user creation failed: \(error.localizedDescription)")
+                    Auth.auth().signIn(withEmail: email, password: password) { authResult, error in
+                        if let error = error {
+                            print("DEBUG: Firebase login failed: \(error.localizedDescription)")
+                            completion(false)
+                        } else {
+                            print("DEBUG: Firebase login success")
+                            guard let uid = authResult?.user.uid else {
+                                completion(false)
+                                return
+                            }
+                            self.saveUserWithDefaultProfileImage(uid: uid, user: user) {
+                                completion(true)
+                            }
+                        }
+                    }
+                } else {
+                    print("DEBUG: Firebase user creation success")
+                    guard let uid = result?.user.uid else {
+                        completion(false)
+                        return
+                    }
+                    self.saveUserWithDefaultProfileImage(uid: uid, user: user) {
+                        completion(true)
+                    }
+                }
+            }
+            return
+        default:
+            print("Unknown login type")
+            completion(false)
+            return
+        }
+        
+        // Firebase에 로그인
+        Auth.auth().signIn(with: credential) { authResult, error in
+            if let error = error {
+                print("DEBUG: Firebase Sign In Error: \(error.localizedDescription)")
+                completion(false)
+                return
+            }
+            
+            guard let uid = authResult?.user.uid else {
+                completion(false)
+                return
+            }
+            
+            // 기본 프로필 이미지 부여 후 Firestore에 사용자 정보 저장
+            self.saveUserWithDefaultProfileImage(uid: uid, user: user) {
                 completion(true)
             }
         }
-        
-        termsVC.onAgreementDeclined = {
-            
-            guard let uid = Auth.auth().currentUser?.uid else {
-                           completion(false)
-                           return
-                       }
-            print("userUID - \(uid)")
-            
-            self.deleteUserFromFirestore(uid: uid) { success in
-                if success {
-                    self.signOutAndDeleteUser {
-                        completion(false)
-                    }
-                } else {
-                    completion(false)
-                }
-            }
-        }
-        presentingViewController.present(termsVC, animated: false,completion: nil)
-        
     }
-    //회원가입시 유저에게 기본 프로필 이미지 부여하는 함수
-    private func saveUserWithDefaultProfileImage(uid:String,user:AuthUser,completion: @escaping () -> Void) {
-        let defaultProfileImageRef = Storage.storage().reference().child("profile_images/default_profile.jpg")
-        
-        defaultProfileImageRef.downloadURL { url, error in
-            if let error = error {
-                print("DEBUG: DefaultProfile Image 에러 발생 - \(error.localizedDescription)")
-                completion()
-                return
-            }
-            
-            guard let downloadURL = url else {
-                print("DEBUG: Default Profile image URL 없음")
-                completion()
-                return
-            }
-            self.saveUserToFirestore(uid: uid, user: user, profileImageURL: downloadURL.absoluteString, completion: completion)
-            
-        }
-    }
-    // 부여되는 기본 프로필과 함께 유저 정보 FireStore에 저장하는 함수 - 문서는 유저 고유 UID 로 저장되어 검색 가능
-    private func saveUserToFirestore(uid: String, user: AuthUser, profileImageURL:String,completion: @escaping () -> Void) {
+    
+    private func saveUserToFirestore(uid: String, user: AuthUser, completion: @escaping () -> Void) {
         let db = Firestore.firestore()
         let userData: [String: Any] = [
             "uid": uid,
             "email": user.email ?? "",
             "name": user.name ?? "",
-            "profileImageURL": profileImageURL,
-            "loginType" : user.loginType
-            //user.profile?.imageURL(withDimension: 100)?.absoluteString ?? ""
+            "loginType": user.loginType,
+            "providerUID": user.providerUID
         ]
         
         db.collection("users").document(uid).setData(userData) { error in
             if let error = error {
                 print("Error saving user data: \(error.localizedDescription)")
+                completion()
             } else {
                 print("유저 정보 저장 성공 ")
                 completion()
             }
         }
     }
-    // 회원가입 진행 중 유저가 취소했을경우 해당 유저 정보 FireStore에서 삭제하는 함수
-    private func deleteUserFromFirestore(uid: String, completion: @escaping (Bool) -> Void) {
-        let db = Firestore.firestore()
-        db.collection("users").document(uid).delete { error in
-            if let error = error {
-                print("Error deleting user data: \(error.localizedDescription)")
-                completion(false)
-            } else {
-                print("User data deleted successfully")
-                completion(true)
+    
+    // 약관 동의 VIEW로 이동하는 함수
+    private func navigateToTermsAgreementView(user: AuthUser, presentingViewController: UIViewController, completion: @escaping (Bool) -> Void) {
+        let termsVC = TermsAgreementViewController(user: user)
+        termsVC.modalPresentationStyle = .fullScreen
+        termsVC.onAgreementAccepted = {
+            // 회원가입 진행 시 사용자의 Firebase Auth 등록
+            self.createFirebaseUser(user: user) { success in
+                if success, let uid = Auth.auth().currentUser?.uid {
+                    // 기본 프로필 이미지 부여 후 Firestore에 사용자 정보 저장
+                    self.saveUserWithDefaultProfileImage(uid: uid, user: user) {
+                        completion(true)
+                    }
+                } else {
+                    completion(false)
+                }
             }
         }
+        
+        
+        termsVC.onAgreementDeclined = {
+            completion(false)
+        }
+        
+        presentingViewController.present(termsVC, animated: true, completion: nil)
     }
     
-    // 회원가입 진행 중 유저가 취소했을경우 해당 유저 Authentication 에서 삭제 및 로그아웃
-    private func signOutAndDeleteUser(completion: @escaping () -> Void) {
-        guard let user = Auth.auth().currentUser else {
-            completion()
-            return
-        }
-        user.delete { error in
-            if let error = error {
-                print("Error deleting user: \(error.localizedDescription)")
-            } else {
-                print("User deleted successfully")
+    // 기타 필요한 함수들
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: Array<Character> = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
             }
-            completion()
+            
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
         }
-        do {
-            try Auth.auth().signOut()
-        } catch let signOutError as NSError {
-            print("Error signing out: \(signOutError.localizedDescription)")
-        }
+        
+        return result
     }
     
-    // 유저 상태 감지 함수?
-    func addAuthStateDidChangeListener(completion: @escaping (FirebaseAuth.User?) -> Void) {
-        Auth.auth().addStateDidChangeListener { _ , user in
-            completion(user)
-        }
+    @available(iOS 13, *)
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
+        
+        return hashString
     }
 }
-
 
 //MARK: -  애플 로그인 관련 구현 함수들
 extension AuthService: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
@@ -308,28 +311,17 @@ extension AuthService: ASAuthorizationControllerDelegate, ASAuthorizationControl
                 loginCompletion?(false)
                 return
             }
-            let credential = OAuthProvider.credential(providerID:.apple , idToken: idTokenString, rawNonce: nonce)
             
-            Auth.auth().signIn(with: credential) { authResult, error in
-                if let error = error {
-                    print("DEBUG: Error authenticating: \(error.localizedDescription)")
-                    self.loginCompletion?(false)
-                    return
-                }
-                
-                guard let uid = authResult?.user.uid else {
-                    self.loginCompletion?(false)
-                    return
-                }
-                
-                let appleUser = AppleAuthUser(credential: appleIDCredential)
+            let appleUser = AppleAuthUser(credential: appleIDCredential)
             
-                self.checkIfUserExists(uid: uid, email: appleUser.email, name: appleUser.name) { exists in
-                    if exists {
-                        self.loginCompletion?(true)
-                    } else {
-                        self.navigateToTermsAgreementView(user: appleUser, presentingViewController: presentingViewController, completion: self.loginCompletion ?? { _ in })
-                    }
+            // 소셜 로그인 성공 후 Firestore에서 유저 존재 여부 확인
+            self.checkIfUserExists(providerUID: appleUser.uid, loginType: appleUser.loginType) { exists in
+                if exists {
+                    // 유저가 존재하면 로그인 처리
+                    self.loginCompletion?(true)
+                } else {
+                    // 유저가 존재하지 않으면 약관 동의 뷰로 이동
+                    self.navigateToTermsAgreementView(user: appleUser, presentingViewController: presentingViewController, completion: self.loginCompletion ?? { _ in })
                 }
             }
         } else {
@@ -337,57 +329,16 @@ extension AuthService: ASAuthorizationControllerDelegate, ASAuthorizationControl
         }
     }
     
-    
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return UIApplication.shared.windows.first { $0.isKeyWindow } ?? UIWindow()
     }
-   
-    private func randomNonceString(length: Int = 32) -> String {
-        precondition(length > 0)
-        let charset: Array<Character> = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-        var result = ""
-        var remainingLength = length
-
-        while remainingLength > 0 {
-            let randoms: [UInt8] = (0 ..< 16).map { _ in
-                var random: UInt8 = 0
-                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
-                if errorCode != errSecSuccess {
-                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
-                }
-                return random
-            }
-
-            randoms.forEach { random in
-                if remainingLength == 0 {
-                    return
-                }
-                if random < charset.count {
-                    result.append(charset[Int(random)])
-                    remainingLength -= 1
-                }
-            }
-        }
-
-        return result
-    }
-
-    @available(iOS 13, *)
-    private func sha256(_ input: String) -> String {
-        let inputData = Data(input.utf8)
-        let hashedData = SHA256.hash(data: inputData)
-        let hashString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
-
-        return hashString
-    }
-    
 }
 
-//MARK: -  카카오 로그인 관련 구현 함수들
+//MARK: - 카카오 로그인 관련 구현 함수들
 extension AuthService {
     // 카카오 로그인 요청
     private func requestKakaoOauth(presentingViewController: UIViewController, completion: @escaping (Bool) -> Void) {
-        // 카카오톡이 있을경우
+        // 카카오톡이 있을 경우
         if UserApi.isKakaoTalkLoginAvailable() {
             UserApi.shared.loginWithKakaoTalk { oauthToken, error in
                 if let error = error {
@@ -411,7 +362,6 @@ extension AuthService {
             }
         }
     }
-
     
     private func getKakaoUserInfo(presentingViewController: UIViewController, completion: @escaping (Bool) -> Void) {
         UserApi.shared.me { user, error in
@@ -432,62 +382,64 @@ extension AuthService {
             }
             
             let kakaoUser = KakaoAuthUser(user: user)
-            let password = String(describing: user.id)
-            print("kakaoUser = \(kakaoUser),- \(password)")
             
-            // 파이어베이스에 사용자 생성 시도
-            Auth.auth().createUser(withEmail:kakaoUser.email!, password: password) { result, error in
-                if let error = error {
-                    print("DEBUG: 파이어베이스 사용자 생성 실패 \(error.localizedDescription)")
-                    
-                    // 사용자 생성이 실패하면, 로그인 시도
-                    Auth.auth().signIn(withEmail: kakaoUser.email!, password: password) { authResult, error in
-                        if let error = error {
-                            print("DEBUG: 파이어베이스 로그인 실패 \(error.localizedDescription)")
-                            completion(false)
-                        } else {
-                            print("DEBUG: 파이어베이스 로그인 성공")
-                            
-                            // 유저가 이미 존재하는 경우, Firestore에서 확인 및 저장 로직
-                            guard let uid = authResult?.user.uid else {
-                                completion(false)
-                                return
-                            }
-                            
-                            self.checkIfUserExists(uid: uid, email: kakaoUser.email, name: kakaoUser.name) { exists in
-                                if exists {
-                                    completion(true)
-                                } else {
-                                    // 유저 정보가 Firestore에 없으면 이는 비정상적인 상태이므로 에러 발생
-                                    print("DEBUG: Firestore에 유저 정보가 없습니다. 비정상적인 상태.")
-                                    completion(false)
-                                }
-                            }
-                        }
-                    }
-                    
+            // 소셜 로그인 성공 후 Firestore에서 유저 존재 여부 확인
+            self.checkIfUserExists(providerUID: kakaoUser.uid, loginType: kakaoUser.loginType) { exists in
+                if exists {
+                    // 유저가 존재하면 바로 로그인 처리
+                    completion(true)
                 } else {
-                    print("DEBUG: 파이어베이스 사용자 생성 성공")
-                    
-                    // 새로 사용자 생성에 성공한 경우, 약관 동의 뷰로 이동
-                    guard let uid = result?.user.uid else {
-                        completion(false)
-                        return
-                    }
-                    
-                    self.navigateToTermsAgreementView(user: kakaoUser, presentingViewController: presentingViewController) { success in
-                        if success {
-                            // 약관 동의 완료 후 유저 정보 저장
-                            self.saveUserWithDefaultProfileImage(uid: uid, user: kakaoUser) {
-                                completion(true)
-                            }
-                        } else {
-                            completion(false)
-                        }
-                    }
+                    // 유저가 존재하지 않으면 약관 동의 뷰로 이동
+                    self.navigateToTermsAgreementView(user: kakaoUser, presentingViewController: presentingViewController, completion: completion)
                 }
             }
         }
     }
-
+    
+    
+    
+    // 기본 프로필 이미지 부여 및 Firestore에 사용자 정보 저장
+    private func saveUserWithDefaultProfileImage(uid: String, user: AuthUser, completion: @escaping () -> Void) {
+        let defaultProfileImageRef = Storage.storage().reference().child("profile_images/default_profile.jpg")
+        
+        defaultProfileImageRef.downloadURL { url, error in
+            if let error = error {
+                print("DEBUG: DefaultProfile Image 에러 발생 - \(error.localizedDescription)")
+                completion()
+                return
+            }
+            
+            guard let downloadURL = url else {
+                print("DEBUG: Default Profile image URL 없음")
+                completion()
+                return
+            }
+            
+            // Firestore에 사용자 정보를 저장
+            self.saveUserToFirestore(uid: uid, user: user, profileImageURL: downloadURL.absoluteString, completion: completion)
+        }
+    }
+    
+    // Firestore에 사용자 정보를 저장하는 함수
+    private func saveUserToFirestore(uid: String, user: AuthUser, profileImageURL: String, completion: @escaping () -> Void) {
+        let db = Firestore.firestore()
+        let userData: [String: Any] = [
+            "uid": uid,
+            "email": user.email ?? "",
+            "name": user.name ?? "",
+            "loginType": user.loginType,
+            "providerUID": user.providerUID,
+            "defaultImageURL": profileImageURL // 기본 프로필 이미지 URL 추가
+        ]
+        
+        db.collection("users").document(uid).setData(userData) { error in
+            if let error = error {
+                print("Error saving user data: \(error.localizedDescription)")
+            } else {
+                print("유저 정보 저장 성공")
+            }
+            completion()
+        }
+    }
+    
 }

--- a/ReptileHub/Service/AuthService.swift
+++ b/ReptileHub/Service/AuthService.swift
@@ -429,7 +429,7 @@ extension AuthService {
             "name": user.name ?? "",
             "loginType": user.loginType,
             "providerUID": user.providerUID,
-            "defaultImageURL": profileImageURL // 기본 프로필 이미지 URL 추가
+            "profileImageURL": profileImageURL // 기본 프로필 이미지 URL 추가
         ]
         
         db.collection("users").document(uid).setData(userData) { error in

--- a/ReptileHub/Service/CommunityService.swift
+++ b/ReptileHub/Service/CommunityService.swift
@@ -17,8 +17,15 @@ class CommunityService {
     private let storageRef = Storage.storage().reference()
 
     //MARK: - 커뮤니티 게시글 작성 후 등록 함수
-    func createPost(userID: String, title: String, content: String, images: [Data], completion: @escaping (Error?) -> Void) {
-        uploadImages(images: images) { urls, errors in
+    func createPost(userID: String, title: String, content: String, images: [Data]?, completion: @escaping (Error?) -> Void) {
+        // 이미지가 없는 경우 바로 Firestore에 저장
+        if images == nil || images!.isEmpty {
+            savePostData(userID: userID, title: title, content: content, imageURLs: [], completion: completion)
+            return
+        }
+        
+        // 이미지가 있는 경우 업로드
+        uploadImages(images: images!) { urls, errors in
             if let errors = errors, !errors.isEmpty {
                 completion(errors.first)
                 return
@@ -29,62 +36,68 @@ class CommunityService {
                 return
             }
             
-            let postID = UUID().uuidString
-            let previewContent = String(content.prefix(40))
-            
-            let db = Firestore.firestore()
-            let userRef = db.collection("users").document(userID)
-            
-            db.runTransaction({ (transaction, errorPointer) -> Any? in
-                do {
-                    // 유저의 문서를 가져옴
-                    let userDocument = try transaction.getDocument(userRef)
-                    
-                    // 현재 게시글 개수를 가져와서 1을 추가
-                    let currentPostCount = userDocument.data()?["postCount"] as? Int ?? 0
-                    transaction.updateData(["postCount": currentPostCount + 1], forDocument: userRef)
-                    
-                    // 썸네일 정보 저장
-                    let thumbnailData: [String: Any] = [
-                        "postID": postID,
-                        "userID": userID,
-                        "thumbnail": urls.first ?? "", // 첫 번째 이미지를 썸네일로 사용
-                        "title": title,
-                        "previewContent": previewContent,
-                        "createdAt": FieldValue.serverTimestamp(),
-                        "likeCount": 0,
-                        "commentCount": 0
-                    ]
-                    
-                    let postRef = db.collection("posts").document(postID)
-                    transaction.setData(thumbnailData, forDocument: postRef)
-                    
-                    // 상세 정보 저장
-                    let postData: [String: Any] = [
-                        "postID": postID,
-                        "userID": userID,
-                        "title": title,
-                        "content": content,
-                        "imageURLs": urls,
-                        "createdAt": FieldValue.serverTimestamp(),
-                        "likeCount": 0,
-                        "commentCount": 0
-                    ]
-                    
-                    let detailRef = postRef.collection("post_details").document(postID)
-                    transaction.setData(postData, forDocument: detailRef)
-                    
-                    return nil
-                } catch {
-                    errorPointer?.pointee = error as NSError
-                    return nil
-                }
-            }) { (result, error) in
-                if let error = error {
-                    completion(error)
-                } else {
-                    completion(nil)
-                }
+            // Firestore에 저장
+            self.savePostData(userID: userID, title: title, content: content, imageURLs: urls, completion: completion)
+        }
+    }
+    
+    // Firestore에 게시글 데이터를 저장하는 함수
+    private func savePostData(userID: String, title: String, content: String, imageURLs: [String], completion: @escaping (Error?) -> Void) {
+        let postID = UUID().uuidString
+        let previewContent = String(content.prefix(40))
+        
+        let db = Firestore.firestore()
+        let userRef = db.collection("users").document(userID)
+        
+        db.runTransaction({ (transaction, errorPointer) -> Any? in
+            do {
+                // 유저의 문서를 가져옴
+                let userDocument = try transaction.getDocument(userRef)
+                
+                // 현재 게시글 개수를 가져와서 1을 추가
+                let currentPostCount = userDocument.data()?["postCount"] as? Int ?? 0
+                transaction.updateData(["postCount": currentPostCount + 1], forDocument: userRef)
+                
+                // 썸네일 정보 저장
+                let thumbnailData: [String: Any] = [
+                    "postID": postID,
+                    "userID": userID,
+                    "thumbnail": imageURLs.first ?? "", // 첫 번째 이미지를 썸네일로 사용 (없으면 빈 문자열)
+                    "title": title,
+                    "previewContent": previewContent,
+                    "createdAt": FieldValue.serverTimestamp(),
+                    "likeCount": 0,
+                    "commentCount": 0
+                ]
+                
+                let postRef = db.collection("posts").document(postID)
+                transaction.setData(thumbnailData, forDocument: postRef)
+                
+                // 상세 정보 저장
+                let postData: [String: Any] = [
+                    "postID": postID,
+                    "userID": userID,
+                    "title": title,
+                    "content": content,
+                    "imageURLs": imageURLs,
+                    "createdAt": FieldValue.serverTimestamp(),
+                    "likeCount": 0,
+                    "commentCount": 0
+                ]
+                
+                let detailRef = postRef.collection("post_details").document(postID)
+                transaction.setData(postData, forDocument: detailRef)
+                
+                return nil
+            } catch {
+                errorPointer?.pointee = error as NSError
+                return nil
+            }
+        }) { (result, error) in
+            if let error = error {
+                completion(error)
+            } else {
+                completion(nil)
             }
         }
     }

--- a/ReptileHub/Service/CommunityService.swift
+++ b/ReptileHub/Service/CommunityService.swift
@@ -163,8 +163,17 @@ class CommunityService {
                     )
                     thumbnails.append(thumbnailResponse)
                 }
-                
             }
+            
+            // createdAt 기준으로 내림차순 정렬
+           
+            thumbnails.sort {
+                guard let date1 = $0.createdAt, let date2 = $1.createdAt else {
+                    return false
+                }
+                return date1 > date2
+            }
+            
             // completion으로 전송
             completion(.success(thumbnails))
             

--- a/ReptileHub/Service/CommunityService.swift
+++ b/ReptileHub/Service/CommunityService.swift
@@ -376,7 +376,7 @@ class CommunityService {
     }
 
     //MARK: - 댓글 작성 함수
-    func addComment(postID: String, userID: String, content: String, completion: @escaping (Error?) -> Void) {
+    func addComment(postID: String, userID: String, content: String, completion: @escaping (Result<[CommentResponse], Error>) -> Void) {
         let db = Firestore.firestore()
         let commentID = UUID().uuidString
         let createdAt = FieldValue.serverTimestamp()
@@ -421,10 +421,11 @@ class CommunityService {
         }) { (result, error) in
             if let error = error {
                 print("Failed to add comment: \(error.localizedDescription)")
-                completion(error)
+                completion(.failure(error))
             } else {
                 print("댓글 추가 완료!!")
-                completion(nil)
+                // 댓글 추가 완료 후, 해당 포스트의 모든 댓글을 가져옴
+                self.fetchComments(forPost: postID, completion: completion)
             }
         }
     }

--- a/ReptileHub/Service/DiaryPostService.swift
+++ b/ReptileHub/Service/DiaryPostService.swift
@@ -146,29 +146,42 @@ class DiaryPostService {
     }
     
     //MARK: - DiaryDetail 정보 불러오는 함수. 썸네일에서 받아온 diaryID 를 할당해서 조회 하면 해당 detail 정보를 받을 수 있다 .
-    func fetchGrowthDiaryDetails(userID: String, diaryID: String, completion: @escaping (GrowthDiaryResponse?) -> Void) {
+    func fetchGrowthDiaryDetails(userID: String, diaryID: String, completion: @escaping (Result<GrowthDiaryResponse, Error>) -> Void) {
         db.collection("users").document(userID)
             .collection("growth_diaries_details")
             .document(diaryID)
             .getDocument { (document, error) in
                 if let error = error {
                     print("Error getting document: \(error)")
-                    completion(nil)
+                    completion(.failure(error))
                     return
                 }
                 
-                guard let document = document, document.exists else {
-                    print("Document does not exist")
-                    completion(nil)
+                guard let document = document, let data = document.data() else {
+                    print("Document does not exist or no data available")
+                    let noDataError = NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Document does not exist or no data available"])
+                    completion(.failure(noDataError))
                     return
                 }
                 
-                print("Document data: \(document.data() ?? [:])")  // Document의 데이터 확인
-                if let diaryResponse = try? document.data(as: GrowthDiaryResponse.self) {
-                    completion(diaryResponse)
-                } else {
-                    print("Failed to decode DiaryResponse")  // 디코딩 실패 여부 확인
-                    completion(nil)
+                do {
+                    // 수동으로 데이터를 파싱하여 GrowthDiaryResponse 객체를 생성
+                    let lizardInfo = try JSONDecoder().decode(LizardInfoResponse.self, from: JSONSerialization.data(withJSONObject: data["lizardInfo"] as Any))
+                    
+                    var parentInfo: ParentsResponse? = nil
+                    if let parentInfoData = data["parentInfo"] as? [String: Any] {
+                        let mother = try JSONDecoder().decode(ParentInfoResponse.self, from: JSONSerialization.data(withJSONObject: parentInfoData["mother"] as Any))
+                        let father = try JSONDecoder().decode(ParentInfoResponse.self, from: JSONSerialization.data(withJSONObject: parentInfoData["father"] as Any))
+                        
+                        parentInfo = ParentsResponse(mother: mother, father: father)
+                    }
+                    
+                    let diaryResponse = GrowthDiaryResponse(lizardInfo: lizardInfo, parentInfo: parentInfo)
+                    print("diaryResponse \(diaryResponse)")
+                    completion(.success(diaryResponse))
+                } catch {
+                    print("Failed to decode diary details: \(error)")
+                    completion(.failure(error))
                 }
             }
     }

--- a/ReptileHub/Service/UserService.swift
+++ b/ReptileHub/Service/UserService.swift
@@ -144,9 +144,8 @@ class UserService {
                   let uid = data["uid"] as? String,
                   let name = data["name"] as? String,
                   let profileImageURL = data["profileImageURL"] as? String,
-
-                  let loginType = data["loginType"] as? String
-            else {
+                  let providerUID = data["providerUID"] as? String,
+                  let loginType = data["loginType"] as? String else {
 
                 completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid user data"])))
                 return
@@ -155,7 +154,7 @@ class UserService {
             let lizardCount = data["lizardCount"] as? Int ?? 0
             let postCount = data["postCount"] as? Int ?? 0
             
-            let userProfile = UserProfile(uid: uid, name: name, profileImageURL: profileImageURL, loginType: loginType, lizardCount: lizardCount, postCount: postCount)
+            let userProfile = UserProfile(uid: uid, providerUID: providerUID, name: name, profileImageURL: profileImageURL, loginType: loginType, lizardCount: lizardCount, postCount: postCount)
             completion(.success(userProfile))
         }
     }

--- a/ReptileHub/Service/UserService.swift
+++ b/ReptileHub/Service/UserService.swift
@@ -137,12 +137,13 @@ class UserService {
                   let uid = data["uid"] as? String,
                   let name = data["name"] as? String,
                   let profileImageURL = data["profileImageURL"] as? String,
-                  let loginType = data["loginType"] as? String,
-                  let lizardCount = data["lizardCount"] as? Int,
-                  let postCount = data["postCount"] as? Int else {
+                  let loginType = data["loginType"] as? String else {
                 completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid user data"])))
                 return
             }
+            
+            let lizardCount = data["lizardCount"] as? Int ?? 0
+            let postCount = data["postCount"] as? Int ?? 0
             
             let userProfile = UserProfile(uid: uid, name: name, profileImageURL: profileImageURL, loginType: loginType, lizardCount: lizardCount, postCount: postCount)
             completion(.success(userProfile))

--- a/ReptileHub/View/Profile/EditUserInfoView.swift
+++ b/ReptileHub/View/Profile/EditUserInfoView.swift
@@ -14,7 +14,7 @@ class EditUserInfoView: UIView {
     
     // UserProfile 더미 데이터
     let users: [UserProfile] = [
-        UserProfile(uid: "1001", name: "고앵이", profileImageURL: "profile", loginType: "profile2", lizardCount: 5, postCount: 12)
+        UserProfile(uid: "1001", providerUID: "123", name: "고앵이", profileImageURL: "profile", loginType: "profile2", lizardCount: 5, postCount: 12)
     ]
 
     var ProfileImageEdit: UIImageView = {

--- a/ReptileHub/View/Profile/ProfileView.swift
+++ b/ReptileHub/View/Profile/ProfileView.swift
@@ -14,7 +14,7 @@ class ProfileView: UIView {
     // 배경 수정 필요
     // UserProfile 더미 데이터
     let users: [UserProfile] = [
-        UserProfile(uid: "1001", name: "고앵이", profileImageURL: "profile", loginType: "profile2", lizardCount: 5, postCount: 12)
+        UserProfile(uid: "1001", providerUID: "123", name: "고앵이", profileImageURL: "profile", loginType: "profile2", lizardCount: 5, postCount: 12)
     ]
 
     // MARK: - Properties (프로필 이미지, 이름, 스택뷰, 테이블뷰 등)

--- a/ReptileHub/View/Profile/WritePostListTableViewCell.swift
+++ b/ReptileHub/View/Profile/WritePostListTableViewCell.swift
@@ -11,7 +11,7 @@ import SnapKit
 class WritePostListTableViewCell: UITableViewCell {
     
     let users: [UserProfile] = [
-        UserProfile(uid: "1001", name: "고앵이", profileImageURL: "profile", loginType: "profile2", lizardCount: 5, postCount: 12)
+        UserProfile(uid: "1001", providerUID: "123", name: "고앵이", profileImageURL: "profile", loginType: "profile2", lizardCount: 5, postCount: 12)
     ]
     
     let posts: [ThumbnailPostResponse] = [


### PR DESCRIPTION
#  📌    Pull Request 

- 요청(이름) :  임재현

## :sparkles: PR 내용
- 기능 추가 [v] 
- 기능 수정[v]
- 기능 삭제 [ ]
- 버그 수정 [ ]

## 🔉  주요 이슈 


## 💻  작업내용

- Login Flow 방식 변경 -> 기존 약관 동의전 Firebase 에 유저 생성 에서 약관동의 완료까지 해야 유저 생성
- 커뮤니티 게시글 작성할떄 이미지 옵셔널하게 보낼수 있도록 수정 
- 댓글 작성, 삭제할때 post_details에 해당 댓글 갯수 카운팅 안되는 부분 수정 
-  유저 프로필 정보 불러올때 필드 내용이 달라서 불러오지 못하는 에러 수정 
-  성장일지 DatePicker Date 필드 추가
- 커뮤니티 게시글 내림차순 정렬 fetch 하도록 변경
-  addComment 후 바로 fetchComments 할수 있도록 수정
-  fetchGrowthDiaryDetails response type Result 타입으로 변경


## 문제발생/해결(선택)

1. lizardCount 와 postCount 는 유저가 처음 글을 작성했을때 생성되는 필드여서, 처음에 유저 프로필 가져올떄 불러오지 못하는 에러 발생
  - 해결방법: 해당 postCount,lizardCount 에 nil 값일 경우 옵셔널 체이닝으로 default값인 0 부여, 이후에 유저가 글을 작성하거나 삭제하면 카운팅 되도록 로직 수정 

2. 회원가입 Flow 에서 소셜 로그인 성공 후, 약관 동의까지 해야 유저 정보가 생성되어야 하는데 소셜 로그인만 성공해도 유저 정보가 파베에 저장되고, decline 버튼을 누르면 해당 유저 탈퇴 및 DB 에서 삭제하도록 구현함.
-> decline을 누르지 않고 유저가 앱을 종료하거나 에러가 뜨면 해당 유저는 약관동의를 하지도 않았는데 회원가입이 되는 오류 발생 

- 해결방법:  소셜 로그인 성공하고, 해당 토큰으로 credential 만들어서 Auth.auth().signIn 해주기 전, 해당 소셜 로그인 provider 고유 uid 랑 유저 정보가 DB 에 있는지 확인후 없을경우 회원가입, 있을경우 기존 유저로 바로 로그인 할 수 있도록 분기처리하고 , 
 회원가입에서 약관 동의하기 버튼을 눌러야지 signIn 으로 회원가입 하면서 유저 정보를 db에 저장하도록 수정 
ㄴ 기존유저는 바로 로그인 / 신규 유저는 약관동의 이동 후 약관 동의를 모두 완료해야 회원가입 되도록 수정

## 📷  스크린샷(선택)


## ☕ : 리뷰 요구사항  

-  로그인 에러나면 말씀해주세요 ~
-  그외 Firebase CRUD 관련 에러나 안되는 부분 있으시면 말씀해 주시면 확인 후 수정하도록 하겠습니다~ 




