### PR TITLE
Community - UISearchBar추가 & 게시글, 댓글 삭제 & 유저 차단 & UIMenu 분기처리

### DIFF
--- a/ReptileHub.xcodeproj/project.pbxproj
+++ b/ReptileHub.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		589CCFFF2C608FFF00812D17 /* CommunityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CCFFE2C608FFF00812D17 /* CommunityViewController.swift */; };
 		589CD0012C60901500812D17 /* GrowthDiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589CD0002C60901500812D17 /* GrowthDiaryViewController.swift */; };
 		58C61A042C7A530F00E1FD3A /* KeyboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C61A032C7A530F00E1FD3A /* KeyboardDelegate.swift */; };
-		58CD8FC52C8232ED0009CE9C /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 58CD8FC42C8232ED0009CE9C /* Kingfisher */; };
 		58F3F6402C772E6B00FDABD1 /* CommunityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F63F2C772E6B00FDABD1 /* CommunityDetailView.swift */; };
 		58F3F6422C781DF500FDABD1 /* AddPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6412C781DF500FDABD1 /* AddPostViewController.swift */; };
 		58F3F6442C781F1400FDABD1 /* AddPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F3F6432C781F1400FDABD1 /* AddPostView.swift */; };
@@ -739,7 +738,7 @@
 				CODE_SIGN_ENTITLEMENTS = ReptileHub/ReptileHub.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P95R3MRRWK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ReptileHub/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = NSPhotoLibraryUsageDescription;
@@ -769,7 +768,7 @@
 				CODE_SIGN_ENTITLEMENTS = ReptileHub/ReptileHub.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P95R3MRRWK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ReptileHub/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = NSPhotoLibraryUsageDescription;

--- a/ReptileHub/Controller/Community/AddPostViewController.swift
+++ b/ReptileHub/Controller/Community/AddPostViewController.swift
@@ -92,7 +92,9 @@ extension AddPostViewController: PHPickerViewControllerDelegate {
 }
 
 extension AddPostViewController: UITextViewDelegate {
+    // 텍스트 뷰의 텍스트가 변경될 때 호출되는 델리게이트 메서드
     func textViewDidChange(_ textView: UITextView) {
+
         if textView.text == "" {
             self.addPostView.textViewPlaceholder.isHidden = false
         } else {
@@ -131,6 +133,7 @@ extension AddPostViewController: AddPostViewDelegate {
                         print("게시글 게시 중 오류 발생: \(error.localizedDescription)")
                     } else {
                         print("게시글 게시 성공")
+                        self.navigationController?.popViewController(animated: true)
                     }
         }
     }

--- a/ReptileHub/Controller/Community/AddPostViewController.swift
+++ b/ReptileHub/Controller/Community/AddPostViewController.swift
@@ -117,15 +117,16 @@ extension AddPostViewController: PHPickerCollectionViewCellDelegate {
 
 extension AddPostViewController: AddPostViewDelegate {
     func didTapPostButton(imageData: [Data], title: String, content: String) {
+        let currentUid = UserService.shared.currentUserId
         print("""
                 [현재 등록할 게시글 내용]
+                userid: \(currentUid)
                 imageData: \(imageData)
                 title: \(title)
                 content: \(content)
                 """)
-        let userID = "R8FK52H2UebtfjNeODkNTEpsOgG3"
         
-        CommunityService.shared.createPost(userID: userID, title: title, content: content, images: imageData) { error in
+        CommunityService.shared.createPost(userID: currentUid, title: title, content: content, images: imageData) { error in
             if let error = error {
                         print("게시글 게시 중 오류 발생: \(error.localizedDescription)")
                     } else {

--- a/ReptileHub/Controller/Community/CommunityDetailViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityDetailViewController.swift
@@ -273,4 +273,5 @@ extension CommunityDetailViewController: CommentTableViewCellDelegate {
         }))
         present(alert, animated: true, completion: nil)
     }
+    
 }

--- a/ReptileHub/Controller/Community/CommunityDetailViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityDetailViewController.swift
@@ -223,7 +223,6 @@ extension CommunityDetailViewController: CommunityDetailViewDelegate {
                 print("댓글 작성 에러 : \(error.localizedDescription)")
             } else {
                 print("댓글 작성 성공!")
-                
                 CommunityService.shared.fetchComments(forPost: postId) { result in
                     switch result {
                     case .success(let commentsData):
@@ -235,8 +234,11 @@ extension CommunityDetailViewController: CommunityDetailViewDelegate {
                             height = height + self.getLabelHeight(tableView: self.detailView.commentTableView, text: comment.content) + 50
                         }
                         self.detailView.updateCommentTableViewHeight(height: height)
-
+                        
                         self.detailView.commentTableView.reloadData()
+                        
+                        // 디테일 뷰의 댓글 카운트 1 증가
+                        self.detailView.grantNewValueCommentCount()
                     case .failure(let error):
                         print("추가된 댓글 포함하여 댓글 가져오기 실패 : \(error.localizedDescription)")
                     }

--- a/ReptileHub/Controller/Community/CommunityDetailViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityDetailViewController.swift
@@ -234,37 +234,57 @@ extension CommunityDetailViewController: UITextViewDelegate {
 
 extension CommunityDetailViewController: CommunityDetailViewDelegate {
     func createCommentAction(postId: String, commentText: String) {
-        CommunityService.shared.addComment(postID: postId, userID: UserService.shared.currentUserId, content: commentText) { error in
-            if let error = error {
-                print("댓글 작성 에러 : \(error.localizedDescription)")
-            } else {
-                print("댓글 작성 성공!")
-                CommunityService.shared.fetchComments(forPost: postId) { result in
-                    switch result {
-                    case .success(let commentsData):
-                        self.fetchComments = commentsData
-                        
-                        var height: CGFloat = 50
-
-                        for comment in self.fetchComments {
-                            height = height + self.getLabelHeight(tableView: self.detailView.commentTableView, text: comment.content) + 50
-                        }
-                        self.detailView.updateCommentTableViewHeight(height: height)
-                        
-                        self.detailView.commentTableView.reloadData()
-                        
-                        // 디테일 뷰의 댓글 카운트 1 증가
-                        self.detailView.addCommentCount()
-                    case .failure(let error):
-                        print("추가된 댓글 포함하여 댓글 가져오기 실패 : \(error.localizedDescription)")
-                    }
-                }
+        CommunityService.shared.addComment(postID: postId, userID: UserService.shared.currentUserId, content: commentText) { result in
+            switch result {
+            case .success(let latestComments):
+                self.fetchComments = latestComments
                 
+                var height: CGFloat = 50
+                
+                for comment in self.fetchComments {
+                    height = height + self.getLabelHeight(tableView: self.detailView.commentTableView, text: comment.content) + 50
+                }
+                self.detailView.updateCommentTableViewHeight(height: height)
+                
+                self.detailView.commentTableView.reloadData()
+                
+                // 디테일 뷰의 댓글 카운트 1 증가
+                self.detailView.addCommentCount()
+            case .failure(let error):
+                print("영등포 차은우 : \(error.localizedDescription)")
             }
         }
     }
     
 }
+
+//error in
+//    if let error = error {
+//        print("댓글 작성 에러 : \(error.localizedDescription)")
+//    } else {
+//        print("댓글 작성 성공!")
+//        CommunityService.shared.fetchComments(forPost: postId) { result in
+//            switch result {
+//            case .success(let commentsData):
+//                self.fetchComments = commentsData
+//                
+//                var height: CGFloat = 50
+//
+//                for comment in self.fetchComments {
+//                    height = height + self.getLabelHeight(tableView: self.detailView.commentTableView, text: comment.content) + 50
+//                }
+//                self.detailView.updateCommentTableViewHeight(height: height)
+//                
+//                self.detailView.commentTableView.reloadData()
+//                
+//                // 디테일 뷰의 댓글 카운트 1 증가
+//                self.detailView.addCommentCount()
+//            case .failure(let error):
+//                print("추가된 댓글 포함하여 댓글 가져오기 실패 : \(error.localizedDescription)")
+//            }
+//        }
+//        
+//    }
 
 extension CommunityDetailViewController: CommentTableViewCellDelegate {
 

--- a/ReptileHub/Controller/Community/CommunityViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityViewController.swift
@@ -196,7 +196,7 @@ extension CommunityViewController: CommunityTableViewCellDelegate {
     }
     
     func blockAlert(cell: CommunityTableViewCell) {
-        let alert = UIAlertController(title: "알림", message: "해당 유저를 삭제하시겠습니까?", preferredStyle: .alert)
+        let alert = UIAlertController(title: "알림", message: "해당 유저를 차단하시겠습니까?", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "취소", style: .cancel, handler: nil))
         alert.addAction(UIAlertAction(title: "차단하기", style: .destructive, handler: { _ in
             // 선택한 셀의 indexPath
@@ -218,18 +218,6 @@ extension CommunityViewController: CommunityTableViewCellDelegate {
                     }
                 }
             }
-            CommunityService.shared.deletePost(postID: self.fetchTestData[indexPath.row].postID, userID: self.fetchTestData[indexPath.row].userID) { error in
-                if let error = error {
-                    print("게시글 삭제 중 오류 발생: \(error.localizedDescription)")
-                } else {
-                    print("게시글 삭제 성공")
-                }
-            }
-            
-            self.fetchTestData.remove(at: indexPath.row)
-            
-            // 선택한 셀을 테이블 뷰에서 삭제
-            self.communityListView.communityTableView.deleteRows(at: [indexPath], with: .automatic)
         }))
         present(alert, animated: true, completion: nil)
     }

--- a/ReptileHub/Controller/Community/CommunityViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityViewController.swift
@@ -108,7 +108,7 @@ extension CommunityViewController: UITableViewDelegate, UITableViewDataSource {
                 
                 if self.isFiltering {
                     let filteredData = self.filteredPosts[indexPath.row]
-                    cell.configure(imageName: filteredData.thumbnailURL, title: filteredData.title, content: filteredData.previewContent, createAt: filteredData.createdAt!.timefomatted, commentCount: filteredData.commentCount, likeCount: filteredData.likeCount, name: userData.name, postUserId:  filteredData.userID
+                    cell.configure(imageName: filteredData.thumbnailURL, title: filteredData.title, content: filteredData.previewContent, createAt: filteredData.createdAt!.timefomatted, commentCount: filteredData.commentCount, likeCount: filteredData.likeCount, name: userData.name, postUserId:  filteredData.userID)
                 } else {
                     cell.configure(imageName: fetchData.thumbnailURL, title: fetchData.title, content: fetchData.previewContent, createAt: fetchData.createdAt!.timefomatted, commentCount: fetchData.commentCount, likeCount: fetchData.likeCount, name: userData.name, postUserId: fetchData.userID)
                 }

--- a/ReptileHub/Controller/Community/CommunityViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityViewController.swift
@@ -39,6 +39,7 @@ class CommunityViewController: UIViewController {
         title = "커뮤니티"
         
         setupSearchButton()
+
     }
     
     override func viewIsAppearing(_ animated: Bool) {
@@ -55,6 +56,7 @@ class CommunityViewController: UIViewController {
             }
         }
     }
+
     
     //MARK: - rightBarButtonItem 적용
     private func setupSearchButton() {

--- a/ReptileHub/Controller/Community/CommunityViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityViewController.swift
@@ -123,19 +123,17 @@ extension CommunityViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let detailViewController = CommunityDetailViewController()
         
-        var postDetailResponse: PostDetailResponse = PostDetailResponse(postID: "", userID: "", title: "", content: "", imageURLs: [], likeCount: 0, commentCount: 0, createdAt: Date(), isLiked: false, isBookmarked: false)
-        
         CommunityService.shared.fetchPostDetail(userID: UserService.shared.currentUserId, postID: self.fetchTestData[indexPath.row].postID) { result in
             switch result {
             case .success(let postDetail):
                 print("상세 게시글 가져오기 성공")
-                postDetailResponse = postDetail
-                
+            
                 UserService.shared.fetchUserProfile(uid: self.fetchTestData[indexPath.row].userID) { result in
                     switch result {
                     case .success(let userData):
                         print("현재 유저 정보 가져오기 성공")
-                        detailViewController.detailView.configureFetchData(profileImageName: userData.profileImageURL, title: postDetailResponse.title, name: userData.name, creatAt:  postDetailResponse.createdAt!.timefomatted, imagesName: postDetailResponse.imageURLs, content: postDetailResponse.content, likeCount: postDetailResponse.likeCount, commentCount: postDetailResponse.commentCount, postID: postDetail.postID, isLiked: postDetail.isLiked, isBookmarked: postDetail.isBookmarked)
+                        
+                        detailViewController.detailView.configureFetchData(postDetailData: postDetail, profileImageName: userData.profileImageURL, name: userData.name)
                         detailViewController.hidesBottomBarWhenPushed = true
                         self.navigationController?.pushViewController(detailViewController, animated: true)
                     case .failure(let error):

--- a/ReptileHub/Controller/Community/CommunityViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityViewController.swift
@@ -108,7 +108,7 @@ extension CommunityViewController: UITableViewDelegate, UITableViewDataSource {
                 
                 if self.isFiltering {
                     let filteredData = self.filteredPosts[indexPath.row]
-                    cell.configure(imageName: filteredData.thumbnailURL, title: filteredData.title, content: filteredData.previewContent, createAt: filteredData.createdAt!.timefomatted, commentCount: filteredData.commentCount, likeCount: filteredData.likeCount, name: userData.name, postUserId:  filteredData.userID)
+                    cell.configure(imageName: filteredData.thumbnailURL, title: filteredData.title, content: filteredData.previewContent, createAt: filteredData.createdAt!.timefomatted, commentCount: filteredData.commentCount, likeCount: filteredData.likeCount, name: userData.name, postUserId:  filteredData.userID
                 } else {
                     cell.configure(imageName: fetchData.thumbnailURL, title: fetchData.title, content: fetchData.previewContent, createAt: fetchData.createdAt!.timefomatted, commentCount: fetchData.commentCount, likeCount: fetchData.likeCount, name: userData.name, postUserId: fetchData.userID)
                 }
@@ -133,7 +133,7 @@ extension CommunityViewController: UITableViewDelegate, UITableViewDataSource {
                     case .success(let userData):
                         print("현재 유저 정보 가져오기 성공")
                         
-                        detailViewController.detailView.configureFetchData(postDetailData: postDetail, profileImageName: userData.profileImageURL, name: userData.name)
+                        detailViewController.detailView.configureFetchData(postDetailData: postDetail, likeCount: self.fetchTestData[indexPath.row].likeCount, commentCount: self.fetchTestData[indexPath.row].commentCount, profileImageName: userData.profileImageURL, name: userData.name)
                         detailViewController.hidesBottomBarWhenPushed = true
                         self.navigationController?.pushViewController(detailViewController, animated: true)
                     case .failure(let error):

--- a/ReptileHub/Controller/Community/CommunityViewController.swift
+++ b/ReptileHub/Controller/Community/CommunityViewController.swift
@@ -143,6 +143,17 @@ extension CommunityViewController: UITableViewDelegate, UITableViewDataSource {
                 
             case .failure(let error):
                 print("상세 게시글 가져오기 실패 : \(error.localizedDescription)")
+                print("해당 게시글은 삭제된 게시글임. 리로드.")
+                CommunityService.shared.fetchAllPostThumbnails(forCurrentUser: UserService.shared.currentUserId) { result in
+                    switch result {
+                    case .success(let newPostList):
+                        self.fetchTestData = newPostList
+                        self.communityListView.communityTableView.reloadData()
+                    case .failure(let error):
+                        print("게시글 다시 불러오기 에러 : \(error.localizedDescription)")
+                    }
+                }
+
             }
         }
 

--- a/ReptileHub/Controller/SpecialNote/SpecialEditViewController.swift
+++ b/ReptileHub/Controller/SpecialNote/SpecialEditViewController.swift
@@ -108,12 +108,12 @@ extension SpecialEditViewController: UITextViewDelegate {
     }
 }
 
-
-extension SpecialEditViewController:SpecialEditViewDelegate {
-   
-    func didTapPostButton(imageData: [Data], date: Date, title: String, text: String) {
-        <#code#>
-    }
-    
-    
-}
+//
+//extension SpecialEditViewController:SpecialEditViewDelegate {
+//   
+//    func didTapPostButton(imageData: [Data], date: Date, title: String, text: String) {
+//        <#code#>
+//    }
+//    
+//    
+//}

--- a/ReptileHub/SceneDelegate.swift
+++ b/ReptileHub/SceneDelegate.swift
@@ -20,20 +20,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
         
-        let tabVC = SpecialEditViewController()
-        window?.rootViewController = tabVC
         
+        if let currentUser = Auth.auth().currentUser {
+            print("과연 지금 유저는? ---------------  \(currentUser.uid)")
+                    // 유저가 로그인 되어 있는 경우 TabbarViewController 설정
+                    let tabVC = TabbarViewController()
+                    window?.rootViewController = tabVC
+                } else {
+                    // 유저가 로그인 되어 있지 않은 경우 LoginViewController 설정
+                    let loginVC = LoginViewController()
+                    window?.rootViewController = loginVC
+                }
         
-//        if let currentUser = Auth.auth().currentUser {
-//            print("과연 지금 유저는? ---------------  \(currentUser.uid)")
-//                    // 유저가 로그인 되어 있는 경우 TabbarViewController 설정
-//                    let tabVC = TabbarViewController()
-//                    window?.rootViewController = tabVC
-//                } else {
-//                    // 유저가 로그인 되어 있지 않은 경우 LoginViewController 설정
-//                    let loginVC = LoginViewController()
-//                    window?.rootViewController = loginVC
-//                }
         self.window?.makeKeyAndVisible()
     }
 

--- a/ReptileHub/Service/CommunityService.swift
+++ b/ReptileHub/Service/CommunityService.swift
@@ -353,6 +353,8 @@ class CommunityService {
         }
     }
 
+
+    
     //MARK: - 댓글 작성 함수
     func addComment(postID: String, userID: String, content: String, completion: @escaping (Error?) -> Void) {
         let db = Firestore.firestore()
@@ -398,6 +400,9 @@ class CommunityService {
             }
         }
     }
+    
+    
+    
     //MARK: - 댓글 불러오기 함수
     func fetchComments(forPost postID:String, completion: @escaping(Result<[CommentResponse],Error>) -> Void) {
         let db = Firestore.firestore()

--- a/ReptileHub/Service/testVC - GrowthDiaryEditViewController.swift
+++ b/ReptileHub/Service/testVC - GrowthDiaryEditViewController.swift
@@ -110,15 +110,15 @@ class GrowthDiaryEditViewController: UIViewController, PHPickerViewControllerDel
     }
     
     private func fetchGrowthDiaryDetails() {
-        let userID = "XYmrUBcFhjdYZSM8TFihX0QNN7O2"
-        let diaryID = "4258CA71-F227-4F28-955F-A79952B33671"
-        DiaryPostService.shared.fetchGrowthDiaryDetails(userID: userID, diaryID: diaryID) { [weak self] diaryResponse in
-            guard let self = self, let diaryResponse = diaryResponse else { return }
-            
-            DispatchQueue.main.async {
-                self.populateData(with: diaryResponse)
-            }
-        }
+//        let userID = "XYmrUBcFhjdYZSM8TFihX0QNN7O2"
+//        let diaryID = "4258CA71-F227-4F28-955F-A79952B33671"
+//        DiaryPostService.shared.fetchGrowthDiaryDetails(userID: userID, diaryID: diaryID) { [weak self] diaryResponse in
+//            guard let self = self, let diaryResponse = diaryResponse else { return }
+//            
+//            DispatchQueue.main.async {
+//                self.populateData(with: diaryResponse)
+//            }
+//        }
     }
     
     private func populateData(with diaryResponse: GrowthDiaryResponse) {

--- a/ReptileHub/View/Community/AddPostView.swift
+++ b/ReptileHub/View/Community/AddPostView.swift
@@ -184,6 +184,8 @@ class AddPostView: UIView {
 }
 
 
+
+
 extension AddPostView: KeyboardNotificationDelegate {
     func keyboardWillShow(keyboardSize: CGRect) {
         print("keyboard Show")
@@ -227,3 +229,4 @@ extension AddPostView: KeyboardNotificationDelegate {
         return false
     }
 }
+

--- a/ReptileHub/View/Community/CommentTableViewCell.swift
+++ b/ReptileHub/View/Community/CommentTableViewCell.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+protocol CommentTableViewCellDelegate: AnyObject {
+    func deleteCommentAction(cell: CommentTableViewCell)
+}
+
 class CommentTableViewCell: UITableViewCell {
+    
+    weak var delegate: CommentTableViewCellDelegate?
     
     // 상단 게시글 정보
     private let profileImage: UIImageView = UIImageView()
@@ -113,8 +119,8 @@ class CommentTableViewCell: UITableViewCell {
         menuButton.tintColor = .gray
         menuButton.transform = CGAffineTransform(rotationAngle: .pi / 2) // 90도 회전
         
-        myMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in  }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in  }) ]
-        otherMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in  }) ]
+        myMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in self.copyCommentAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteCommentAction() }) ]
+        otherMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in self.copyCommentAction() }) ]
         
         menuButton.showsMenuAsPrimaryAction = true
         
@@ -124,6 +130,15 @@ class CommentTableViewCell: UITableViewCell {
             make.top.equalTo(self.contentView.snp.top).offset(10)
             make.trailing.equalTo(self.contentView.snp.trailing)
         }
+    }
+    
+    private func copyCommentAction() {
+        print("댓글 복사하기 클릭.")
+    }
+    
+    private func deleteCommentAction() {
+        print("댓글 삭제하기 클릭.")
+        self.delegate?.deleteCommentAction(cell: self)
     }
 
     //MARK: - configure cell

--- a/ReptileHub/View/Community/CommentTableViewCell.swift
+++ b/ReptileHub/View/Community/CommentTableViewCell.swift
@@ -18,6 +18,8 @@ class CommentTableViewCell: UITableViewCell {
     let elementStackView: UIStackView = UIStackView()
     
     private var menuButton: UIButton = UIButton()
+    private var myMenu: [UIAction] = []
+    private var otherMenu: [UIAction] = []
     
 
     
@@ -111,8 +113,11 @@ class CommentTableViewCell: UITableViewCell {
         menuButton.tintColor = .gray
         menuButton.transform = CGAffineTransform(rotationAngle: .pi / 2) // 90도 회전
         
-        menuButton.addTarget(self, action: #selector(actionMenuButton), for: .touchUpInside)
-            
+        myMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in  }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in  }) ]
+        otherMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in  }) ]
+        
+        menuButton.showsMenuAsPrimaryAction = true
+        
         self.contentView.addSubview(menuButton)
         
         menuButton.snp.makeConstraints { make in
@@ -120,18 +125,18 @@ class CommentTableViewCell: UITableViewCell {
             make.trailing.equalTo(self.contentView.snp.trailing)
         }
     }
-    
-    @objc
-    private func actionMenuButton() {
-        print("메뉴 버튼 클릭.")
-    }
-    
+
     //MARK: - configure cell
-    func configureCell(profileURL: String, name: String, content: String, createAt: String) {
+    func configureCell(profileURL: String, name: String, content: String, createAt: String, commentUserId: String) {
         profileImage.setImage(with: profileURL)
         nameLabel.text = name
         commentLabel.text = content
         timestampLabel.text = createAt
+        
+        let isMine: Bool = commentUserId == UserService.shared.currentUserId
+        
+        menuButton.menu = UIMenu(title: "", image: nil, identifier: nil, options: [], children: isMine ? myMenu : otherMenu)
+
     }
 
 }

--- a/ReptileHub/View/Community/CommentTableViewCell.swift
+++ b/ReptileHub/View/Community/CommentTableViewCell.swift
@@ -37,7 +37,7 @@ class CommentTableViewCell: UITableViewCell {
     
     //MARK: - 프로필 이미지
     private func setupProfileImage() {
-        profileImage.image = UIImage(systemName: "person")
+//        profileImage.image = UIImage(systemName: "person")
         profileImage.backgroundColor = .lightGray
         profileImage.layer.cornerRadius = 20
         profileImage.clipsToBounds = true

--- a/ReptileHub/View/Community/CommentTableViewCell.swift
+++ b/ReptileHub/View/Community/CommentTableViewCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 protocol CommentTableViewCellDelegate: AnyObject {
     func deleteCommentAction(cell: CommentTableViewCell)
+    
+    func blockCommentAction(cell: CommentTableViewCell)
 }
 
 class CommentTableViewCell: UITableViewCell {
@@ -119,8 +121,13 @@ class CommentTableViewCell: UITableViewCell {
         menuButton.tintColor = .gray
         menuButton.transform = CGAffineTransform(rotationAngle: .pi / 2) // 90도 회전
         
-        myMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in self.copyCommentAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteCommentAction() }) ]
-        otherMenu = [ UIAction(title: "복사하기", image: UIImage(systemName: "trash"), handler: { _ in self.copyCommentAction() }) ]
+        myMenu = [ UIAction(title: "텍스트 복사하기", image: UIImage(systemName: "doc.on.doc"), handler: { _ in self.copyCommentAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteCommentAction() }) ]
+        otherMenu = [ UIAction(title: "텍스트 복사하기", image: UIImage(systemName: "doc.on.doc"), handler: { _ in self.copyCommentAction() }), UIAction(title: "작성자 차단하기", image: UIImage(systemName: "hand.raised"), handler: { _ in
+            self.blockCommentAction()
+        }),
+        UIAction(title: "신고하기", image: UIImage(systemName: "exclamationmark.bubble"), attributes: .destructive, handler: { _ in
+            
+        }) ]
         
         menuButton.showsMenuAsPrimaryAction = true
         
@@ -139,6 +146,11 @@ class CommentTableViewCell: UITableViewCell {
     private func deleteCommentAction() {
         print("댓글 삭제하기 클릭.")
         self.delegate?.deleteCommentAction(cell: self)
+    }
+    
+    private func blockCommentAction() {
+        print("댓글 작성자 차단하기 클릭.")
+        self.delegate?.blockCommentAction(cell: self)
     }
 
     //MARK: - configure cell

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -482,6 +482,13 @@ class CommunityDetailView: UIView {
         delegate?.createCommentAction(postId: self.postID, commentText: commentTextView.text)
     }
     
+    func grantNewValueCommentCount() {
+        DispatchQueue.main.async {
+                self.commentCount.text = String((Int(self.commentCount.text ?? "0") ?? 0) + 1)
+                self.commentCount.setNeedsLayout()
+            }
+    }
+    
     
     // UIScrollViewDelegate의 scrollViewDidScroll에 사용
     func imageScrollCount(scrollView: UIScrollView) {

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -8,7 +8,13 @@
 import UIKit
 import SnapKit
 
+protocol CommunityDetailViewDelegate: AnyObject {
+    func createCommentAction(postId: String, commentText: String)
+}
+
 class CommunityDetailView: UIView {
+    
+    weak var delegate: CommunityDetailViewDelegate?
 
     var postID: String = "nil"
     var postUserId: String = "nil"
@@ -473,15 +479,7 @@ class CommunityDetailView: UIView {
     
     @objc
     private func sendButtonAction() {
-        CommunityService.shared.addComment(postID: self.postID, userID: UserService.shared.currentUserId, content: commentTextView.text) { error in
-            if let error = error {
-                print("댓글 게시 중 오류 발생: \(error.localizedDescription)")
-            } else {
-                print("댓글 게시 성공")
-                self.commentTextView.text = ""
-                self.commentTableView.reloadData()
-            }
-        }
+        delegate?.createCommentAction(postId: self.postID, commentText: commentTextView.text)
     }
     
     

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -482,9 +482,16 @@ class CommunityDetailView: UIView {
         delegate?.createCommentAction(postId: self.postID, commentText: commentTextView.text)
     }
     
-    func grantNewValueCommentCount() {
+    func addCommentCount() {
         DispatchQueue.main.async {
                 self.commentCount.text = String((Int(self.commentCount.text ?? "0") ?? 0) + 1)
+                self.commentCount.setNeedsLayout()
+            }
+    }
+    
+    func subtractCommentCount() {
+        DispatchQueue.main.async {
+                self.commentCount.text = String((Int(self.commentCount.text ?? "0") ?? 0) - 1)
                 self.commentCount.setNeedsLayout()
             }
     }

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -151,7 +151,7 @@ class CommunityDetailView: UIView {
     
     //MARK: - 프로필 이미지
     private func setupProfileImage() {
-        profileImage.image = UIImage(systemName: "person")
+//        profileImage.image = UIImage(systemName: "person")
         profileImage.backgroundColor = .lightGray
         profileImage.layer.cornerRadius = 30
         profileImage.clipsToBounds = true
@@ -309,6 +309,7 @@ class CommunityDetailView: UIView {
     private func setupTextView() {
         contentText.text = "게시글 본문 예시 내용입니다."
         contentText.font = UIFont.systemFont(ofSize: 14, weight: .medium)
+        contentText.numberOfLines = 0
 
         self.stackView.addArrangedSubview(contentText)
         

--- a/ReptileHub/View/Community/CommunityDetailView.swift
+++ b/ReptileHub/View/Community/CommunityDetailView.swift
@@ -11,6 +11,7 @@ import SnapKit
 class CommunityDetailView: UIView {
     
     var postID: String = "nil"
+    var postUserId: String = "nil"
     
     // 키보드 탭 제스쳐
     lazy var tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapHandler))
@@ -518,24 +519,25 @@ class CommunityDetailView: UIView {
         commentTextView.delegate = textViewDelegate
     }
     
-    func configureFetchData(profileImageName: String, title: String, name: String, creatAt: String, imagesName: [String], content: String, likeCount: Int, commentCount: Int, postID: String, isLiked: Bool, isBookmarked: Bool) {
-        self.postID = postID
+    func configureFetchData(postDetailData: PostDetailResponse, profileImageName: String, name: String) {
+        self.postID = postDetailData.postID
+        self.postUserId = postDetailData.userID
         
         profileImage.setImage(with: profileImageName)
-        titleLabel.text = title
+        titleLabel.text = postDetailData.title
         nicknameLabel.text = name
-        timestampLabel.text = creatAt
-        contentText.text = content
-        self.likeCount.text = "\(likeCount)"
-        self.commentCount.text = "\(commentCount)"
+        timestampLabel.text = postDetailData.createdAt?.timefomatted
+        contentText.text = postDetailData.content
+        self.likeCount.text = "\(postDetailData.likeCount)"
+        self.commentCount.text = "\(postDetailData.commentCount)"
         
         let imageConfig = UIImage.SymbolConfiguration(pointSize: 23, weight: .medium)
-        let bookmarkImage = UIImage(systemName: isBookmarked ? "bookmark.fill" : "bookmark", withConfiguration: imageConfig)
+        let bookmarkImage = UIImage(systemName: postDetailData.isBookmarked ? "bookmark.fill" : "bookmark", withConfiguration: imageConfig)
         bookMarkButton.setImage(bookmarkImage, for: .normal)
         
         
-        if imagesName.count > 0 {
-            for imageName in imagesName {
+        if postDetailData.imageURLs.count > 0 {
+            for imageName in postDetailData.imageURLs {
                 let imageView: UIImageView = UIImageView()
                 imageView.setImage(with: imageName)
                 

--- a/ReptileHub/View/Community/CommunityTableViewCell.swift
+++ b/ReptileHub/View/Community/CommunityTableViewCell.swift
@@ -174,8 +174,8 @@ class CommunityTableViewCell: UITableViewCell {
     
     //MARK: - menu 버튼
     private func setupMenuButton() {
-        myMenu = [ UIAction(title: "수정하기", image: UIImage(systemName: "trash"), handler: { _ in self.editButtonAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteButtonAction() }) ]
-        otherMenu = [ UIAction(title: "차단하기", image: UIImage(systemName: "trash"), handler: { _ in self.blockButtonAction() }), UIAction(title: "신고하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.reportButtonAction() }) ]
+        myMenu = [ UIAction(title: "게시글 수정하기", image: UIImage(systemName: "square.and.pencil"), handler: { _ in self.editButtonAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteButtonAction() }) ]
+        otherMenu = [ UIAction(title: "작성자 차단하기", image: UIImage(systemName: "hand.raised"), handler: { _ in self.blockButtonAction() }), UIAction(title: "신고하기", image: UIImage(systemName: "exclamationmark.bubble"),attributes: .destructive,handler: { _ in self.reportButtonAction() }) ]
         
         menuButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
         menuButton.contentMode = .scaleAspectFit

--- a/ReptileHub/View/Community/CommunityTableViewCell.swift
+++ b/ReptileHub/View/Community/CommunityTableViewCell.swift
@@ -11,7 +11,13 @@ import Kingfisher
 
 let imageCache = NSCache<NSString, UIImage>()
 
+protocol CommunityTableViewCellDelegate: AnyObject {
+    func deleteAlert(cell: CommunityTableViewCell)
+}
+
 class CommunityTableViewCell: UITableViewCell {
+    
+    weak var delegate: CommunityTableViewCellDelegate?
     
 
     lazy var thumbnailImageView: UIImageView = UIImageView()
@@ -31,7 +37,10 @@ class CommunityTableViewCell: UITableViewCell {
     private let secondStackView: UIStackView = UIStackView()
     
     private let menuButton: UIButton = UIButton()
+    private var myMenu: [UIAction] = []
+    private var otherMenu: [UIAction] = []
     
+
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -47,7 +56,6 @@ class CommunityTableViewCell: UITableViewCell {
     }
     
     override func prepareForReuse() {
-        let config = UIImage.SymbolConfiguration(pointSize: 25, weight: .light)
         thumbnailImageView.image = nil
         titleLabel.text = ""
         contentLabel.text = ""
@@ -60,7 +68,6 @@ class CommunityTableViewCell: UITableViewCell {
     
     //MARK: - Thumnail Image
     private func setupThumbnail() {
-//        thumbnailImageView.image = nil
         thumbnailImageView.contentMode = .scaleAspectFill
         thumbnailImageView.clipsToBounds = true
         thumbnailImageView.layer.cornerRadius = 5
@@ -165,20 +172,42 @@ class CommunityTableViewCell: UITableViewCell {
     
     //MARK: - menu 버튼
     private func setupMenuButton() {
+        myMenu = [UIAction(title: "수정하기", image: UIImage(systemName: "trash"), handler: { _ in self.editButtonAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteButtonAction() })]
+        otherMenu = [ UIAction(title: "차단하기", image: UIImage(systemName: "trash"), handler: { _ in self.blockButtonAction() }), UIAction(title: "신고하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.reportButtonAction() })]
+        
         menuButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
         menuButton.contentMode = .scaleAspectFit
         menuButton.transform = CGAffineTransform(rotationAngle: .pi * 0.5)
+        menuButton.showsMenuAsPrimaryAction = true
         
         self.contentView.addSubview(menuButton)
         
         menuButton.snp.makeConstraints { make in
             make.top.equalTo(self.contentView).offset(5)
             make.trailing.equalTo(self.contentView.snp.trailing).offset(-5)
-            
         }
     }
     
-    func configure(imageName: String, title: String, content: String, createAt: String, commentCount: Int, likeCount: Int, name: String) {
+    private func editButtonAction() {
+        print("edit")
+    }
+    
+    private func deleteButtonAction() {
+        print("delete")
+        delegate?.deleteAlert(cell: self)
+    }
+
+    private func blockButtonAction() {
+        print("block")
+    }
+    
+    private func reportButtonAction() {
+        print("report")
+    }
+    
+    
+    
+    func configure(imageName: String, title: String, content: String, createAt: String, commentCount: Int, likeCount: Int, name: String, postUserId: String) {
 
         thumbnailImageView.setImage(with: imageName)
         
@@ -188,6 +217,12 @@ class CommunityTableViewCell: UITableViewCell {
         commentCountLabel.text = "\(commentCount)"
         bookmarkCountLabel.text = "\(likeCount)"
         nicknameLabel.text = name
+        
+        let isMine: Bool = postUserId == UserService.shared.currentUserId
+        
+        
+        
+        menuButton.menu = UIMenu(title: "", image: nil, identifier: nil, options: [], children: isMine ? myMenu : otherMenu)
     }
     
 }

--- a/ReptileHub/View/Community/CommunityTableViewCell.swift
+++ b/ReptileHub/View/Community/CommunityTableViewCell.swift
@@ -13,13 +13,7 @@ let imageCache = NSCache<NSString, UIImage>()
 
 class CommunityTableViewCell: UITableViewCell {
     
-    var testUserProfile: UserProfile? {
-        didSet {
-            guard let testUserProfile = testUserProfile else { return }
-            self.nicknameLabel.text = testUserProfile.name
-        }
-    }
-    
+
     lazy var thumbnailImageView: UIImageView = UIImageView()
     
     lazy var titleLabel: UILabel = UILabel()
@@ -38,15 +32,7 @@ class CommunityTableViewCell: UITableViewCell {
     
     private let menuButton: UIButton = UIButton()
     
-    
-    //    override func awakeFromNib() {
-    //        super.awakeFromNib()
-    //    }
-    //
-    //    override func setSelected(_ selected: Bool, animated: Bool) {
-    //        super.setSelected(selected, animated: animated)
-    //    }
-    
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
@@ -60,10 +46,21 @@ class CommunityTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        let config = UIImage.SymbolConfiguration(pointSize: 25, weight: .light)
+        thumbnailImageView.image = nil
+        titleLabel.text = ""
+        contentLabel.text = ""
+        commentCountLabel.text = ""
+        bookmarkCountLabel.text = ""
+        nicknameLabel.text = ""
+        timestampLabel.text = ""
+    }
+    
     
     //MARK: - Thumnail Image
     private func setupThumbnail() {
-        thumbnailImageView.image = UIImage(systemName: "camera")
+//        thumbnailImageView.image = nil
         thumbnailImageView.contentMode = .scaleAspectFill
         thumbnailImageView.clipsToBounds = true
         thumbnailImageView.layer.cornerRadius = 5
@@ -75,8 +72,7 @@ class CommunityTableViewCell: UITableViewCell {
         thumbnailImageView.snp.makeConstraints { make in
             make.height.width.equalTo(85)
             make.centerY.equalToSuperview()
-//            make.top.equalTo(self.contentView.snp.top).offset(10)
-//            make.bottom.equalTo(self.contentView.snp.bottom).offset(-10)
+
             make.leading.equalTo(self.contentView.snp.leading).offset(12)
         }
     }
@@ -98,7 +94,6 @@ class CommunityTableViewCell: UITableViewCell {
         mainInfoStackView.snp.makeConstraints { make in
             make.top.equalTo(thumbnailImageView.snp.top)
             make.leading.equalTo(thumbnailImageView.snp.trailing).offset(7)
-//            make.bottom.equalTo(firstStackView.snp.top)
             make.trailing.equalTo(menuButton.snp.leading)
             make.height.greaterThanOrEqualTo(55)
         }
@@ -143,7 +138,7 @@ class CommunityTableViewCell: UITableViewCell {
         secondStackView.alignment = .center
         secondStackView.spacing = 10
         
-        nicknameLabel.text = testUserProfile?.name ?? "구현현서"
+        nicknameLabel.text = "구현현서"
         nicknameLabel.font = UIFont.systemFont(ofSize: 13, weight: .ultraLight)
         timestampLabel.text = "24.08.05 17:00"
         timestampLabel.font = UIFont.systemFont(ofSize: 13, weight: .ultraLight)
@@ -183,7 +178,7 @@ class CommunityTableViewCell: UITableViewCell {
         }
     }
     
-    func configure(imageName: String, title: String, content: String, createAt: String, commentCount: Int, likeCount: Int) {
+    func configure(imageName: String, title: String, content: String, createAt: String, commentCount: Int, likeCount: Int, name: String) {
 
         thumbnailImageView.setImage(with: imageName)
         
@@ -192,6 +187,7 @@ class CommunityTableViewCell: UITableViewCell {
         timestampLabel.text = createAt
         commentCountLabel.text = "\(commentCount)"
         bookmarkCountLabel.text = "\(likeCount)"
+        nicknameLabel.text = name
     }
     
 }

--- a/ReptileHub/View/Community/CommunityTableViewCell.swift
+++ b/ReptileHub/View/Community/CommunityTableViewCell.swift
@@ -13,6 +13,8 @@ let imageCache = NSCache<NSString, UIImage>()
 
 protocol CommunityTableViewCellDelegate: AnyObject {
     func deleteAlert(cell: CommunityTableViewCell)
+    
+    func blockAlert(cell: CommunityTableViewCell)
 }
 
 class CommunityTableViewCell: UITableViewCell {
@@ -189,20 +191,21 @@ class CommunityTableViewCell: UITableViewCell {
     }
     
     private func editButtonAction() {
-        print("edit")
+        print("CommunityTableViewCell edit")
     }
     
     private func deleteButtonAction() {
-        print("delete")
+        print("CommunityTableViewCell delete")
         delegate?.deleteAlert(cell: self)
     }
 
     private func blockButtonAction() {
-        print("block")
+        print("CommunityTableViewCell block")
+        delegate?.blockAlert(cell: self)
     }
     
     private func reportButtonAction() {
-        print("report")
+        print("CommunityTableViewCell report")
     }
     
     

--- a/ReptileHub/View/Community/CommunityTableViewCell.swift
+++ b/ReptileHub/View/Community/CommunityTableViewCell.swift
@@ -172,8 +172,8 @@ class CommunityTableViewCell: UITableViewCell {
     
     //MARK: - menu 버튼
     private func setupMenuButton() {
-        myMenu = [UIAction(title: "수정하기", image: UIImage(systemName: "trash"), handler: { _ in self.editButtonAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteButtonAction() })]
-        otherMenu = [ UIAction(title: "차단하기", image: UIImage(systemName: "trash"), handler: { _ in self.blockButtonAction() }), UIAction(title: "신고하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.reportButtonAction() })]
+        myMenu = [ UIAction(title: "수정하기", image: UIImage(systemName: "trash"), handler: { _ in self.editButtonAction() }), UIAction(title: "삭제하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.deleteButtonAction() }) ]
+        otherMenu = [ UIAction(title: "차단하기", image: UIImage(systemName: "trash"), handler: { _ in self.blockButtonAction() }), UIAction(title: "신고하기", image: UIImage(systemName: "trash"),attributes: .destructive,handler: { _ in self.reportButtonAction() }) ]
         
         menuButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
         menuButton.contentMode = .scaleAspectFit


### PR DESCRIPTION
#  📌    Pull Request 

- 요청(이름) : 조성빈

## :sparkles: PR 내용
- 기능 추가 [v] 
- 기능 삭제 [ ]
- 버그 수정 [V]

## 🔉  주요 이슈 


## 💻  작업내용
- [Fix] CommunityViewController의 37번 줄, AddPostViewController 126번 줄. 하드코딩된  uid 문자열 값을 UserService.shared.currentUserId 로 수정
- [Fix] CommunityTableViewCell - prepareForReuse()으로 재사용 셀 관리
- [Fix/Feat] CommunityViewController - searchButton 제거 및 UIsearchController 추가
  - title’ 기준으로 검색어에 맞는 cell 만 출력
- [Fix] 게시글 디테일 뷰의 content 두줄 이상 안 나오는 문제 수정
- [Feat] CommunityViewController의 리스트 셀 - UIMenu 분기처리(수정/삭제, 차단/신고) 적용 & 삭제 추가
  - CommunityDetailViewController의 메뉴 - 분기처리 적용 & 삭제 추가
- [Feat] CommunityDetailView - 좋아요 기능 추가
- [Feat] AddPostViewController - 게시글 등록 후 pop
- [Feat] 댓글 셀 메뉴 분기처리
- [Feat/Fix] 댓글 작성 시 바로 UI 업데이트
- [Feat] 내가 작성한 댓글 삭제 기능 추가 및 적용
- [Fix] 게시글 리스트 보고있는 와중 타 유저가 게시글 삭제를 하고 업데이트 되지 않은 해당 게시글 클릭시 처리.(삭제된 게시글일 경우 게시글 새로고침)
- [Feat] 게시글 리스트 셀, 디테일 뷰, 댓글에서의 차단과 신고 적용. (신고 부분은 아직 미정으로 별도의 액션 없음)


## 문제발생/해결, 팀원과의 갈등(?)
1. 서버 측과 갈등<댓글 작성시 서버 효율>
    1-1. addComments() → 작성된 댓글 서버에 저장
    1-2. fetchComents() → 특정 게시글에 있는 모든 댓글 fetch
    1-3. [원래의 방법] addComments() 후 fetchComments()로 다시 한 번 모든 댓글을 fetch
        - 단점 : 서버를 한 번 더 훑게됨으로 서버비용에 대한 부담 증가
        - 장점 : 댓글 작성시 새로 추가된 타 유저의 댓글을 새로고침 할 수 있음.
    1-4. [내 방법] addComments()에서 서버에 저장함과 동시에 해당 댓글 프로퍼티를 반환하고, 앱단의 테이블 뷰 셀들의 배열에 append 후 reload.
        - 장점 : 서버비용에 대한 부담은 줄어듦. 
        - 단점 : 댓글 작성시 타 유저가 작성한 댓글 새로고침 불가, 스크롤 하여 새로고침 or 게시글 다시 들어왔을 경우에만 새로고침 가능
        - [내 방법의 참고 코드]
```
//MARK: - 댓글 작성 함수
    func addComment(postID: String, userID: String, content: String, completion: @escaping (Result<CommentResponse, Error>) -> Void) {
        let db = Firestore.firestore()
        let commentID = UUID().uuidString
        let createdAt = FieldValue.serverTimestamp()
        let postRef = db.collection("posts").document(postID)
        
        let commentData: [String: Any] = [
            "commentID": commentID,
            "postID": postID,
            "userID": userID,
            "content": content,
            "createdAt": createdAt,
            "likeCount": 0
        ]
        
        // CommentResponse 프로퍼티를 작성하고 이를 후에 반환
        let resultComment: CommentResponse = CommentResponse(commentID: commentID, postID: postID, userID: userID, content: content, createdAt: Date(), likeCount: 0)
        
        db.runTransaction({ (transaction, errorPointer) -> Any? in
            // 현재 게시글을 가져옴
            let postDocument: DocumentSnapshot
            do {
                postDocument = try transaction.getDocument(postRef)
            } catch let fetchError as NSError {
                errorPointer?.pointee = fetchError
                return nil
            }
            
            // 댓글 수를 가져와 1을 추가
            let currentCommentCount = postDocument.data()?["commentCount"] as? Int ?? 0
            transaction.updateData(["commentCount": currentCommentCount + 1], forDocument: postRef)
            
            // 댓글 추가
            let commentRef = postRef.collection("comments").document(commentID)
            transaction.setData(commentData, forDocument: commentRef)
            
            return nil
        }) { (result, error) in
            if let error = error {
                print("Failed to add comment: \(error.localizedDescription)")
                completion(.failure(error))
            } else {
                print("댓글 추가 완료!!")
                // 작성된 댓글 프로퍼티를 반환하고 서버에 저장.
                completion(.success(resultComment))
            }
        }
    }
    
    // 실 사용
    extension CommunityDetailViewController: CommunityDetailViewDelegate {
    func createCommentAction(postId: String, commentText: String) {
        CommunityService.shared.addComment(postID: postId, userID: UserService.shared.currentUserId, content: commentText) { result in
            switch result {
            case .success(let createdComment):
                self.fetchComments.append(createdComment)
                
                var height: CGFloat = 50
                
                for comment in self.fetchComments {
                    height = height + self.getLabelHeight(tableView: self.detailView.commentTableView, text: comment.content) + 50
                }
                self.detailView.updateCommentTableViewHeight(height: height)
                
                self.detailView.commentTableView.reloadData()
            case .failure(let error):
                print("댓글 작성 실패 : \(error.localizedDescription)")
            }
        }
    }
    
}
```

2. [결론]
상당한 유저를 가지고 있는게 아니라면 당장은 제때제때 댓글 업데이트 제공하는 것 과 당장의 기능 구현에 더 신경을 쓰기로 함. 추후 최신화와 배열 관리만 잘 된다면 서버를 훑는 횟수를 획기적으로 줄이는 괜찮은 방법이니 그때 생각하기로 함.

## 📷  스크린샷(선택)


## ☕ : 리뷰 요구사항  


